### PR TITLE
event driven macropad

### DIFF
--- a/macropad-controller/src/main.py
+++ b/macropad-controller/src/main.py
@@ -107,49 +107,55 @@ if not apps:
         pass
 
 last_position = None
-station_app_index = None
 station_index = None
 last_encoder_switch = macropad.encoder_switch_debounced.pressed
 app_index = 0
 apps[app_index].switch()
 
+
 def radio_control(event, data=None):
     PLAYER.write(f"{event}:{data}\n".encode())
+
 
 def highlight_playing(app_index, station_index):
     """Highlight the currently playing station."""
 
-    group[MACROPAD_KEY_COUNT + 1].text = apps[app_index].stations[station_index].get("name", "?")
+    group[MACROPAD_KEY_COUNT + 1].text = (
+        apps[app_index].stations[station_index].get("name", "?")
+    )
     for i in range(MACROPAD_KEY_COUNT):
         try:
-            macropad.pixels[i] = HIGHLIGHT_COLOR if i == station_index else apps[app_index].stations[i].get("color", DEFAULT_COLOR)
+            macropad.pixels[i] = (
+                HIGHLIGHT_COLOR
+                if i == station_index
+                else apps[app_index].stations[i].get("color", DEFAULT_COLOR)
+            )
         except IndexError:
             macropad.pixels[i] = 0
 
         group[i].color = 0x000000 if i == station_index else 0xFFFFFF
         group[i].background_color = 0xFFFFFF if i == station_index else 0x000000
 
-    
     macropad.pixels.show()
     macropad.display.refresh()
+
 
 # MAIN LOOP ----------------------------
 while True:
     if PLAYER.in_waiting > 0:
-        msg = PLAYER.read(PLAYER.in_waiting).decode('utf-8').strip()
+        msg = PLAYER.read(PLAYER.in_waiting).decode("utf-8").strip()
         event, data = msg.split(":", 1) if ":" in msg else (msg, None)
         if event == "station_playing":
             station_index = None
             for aidx, app in enumerate(apps):
                 for idx, station in enumerate(app.stations):
                     if station.get("name") == data:
-                        station_app_index = aidx
                         station_index = idx
 
                         # If the app index has changed, switch to the correct app
-                        if app_index != station_app_index:
+                        if app_index != aidx:
                             apps[aidx].switch()
-                            app_index = station_app_index
+                            app_index = aidx
 
                         highlight_playing(app_index, station_index)
                         break

--- a/player/README.md
+++ b/player/README.md
@@ -7,7 +7,7 @@ A 🎵 radio station player 🎵 with real-time syncing controllers.
 ### Host Dependencies
 
 - [mpv](https://mpv.io/)
-- [prompt_toolkit](https://python-prompt-toolkit.readthedocs.io/en/master/)
+- [python-websockets](https://websockets.readthedocs.io/en/stable/)
 - [python-mpv-jsonipc](https://github.com/iwalton3/python-mpv-jsonipc)
 - [python-websockets](https://github.com/python-websockets/websockets)
 

--- a/player/requirements.txt
+++ b/player/requirements.txt
@@ -1,5 +1,3 @@
-prompt_toolkit==3.0.51
 pyserial==3.5
 python-mpv-jsonipc==1.2.1
-wcwidth==0.2.13
 websockets==15.0.1


### PR DESCRIPTION
macropad now behaves like a remote controller;
* keys turn grey when pressed
* on station_playing events:
  * if station exists in another page, switches to the correct page (updates appindex)
  * key representing the currently playing station turns green, all others back to their default.