### PR TITLE
feat: surface player registry and network status to macropad

### DIFF
--- a/macropad-control/src/main.py
+++ b/macropad-control/src/main.py
@@ -33,18 +33,18 @@ last_position = macropad.encoder
 last_encoder_switch = macropad.encoder_switch_debounced.pressed
 had_stations = False
 
-display.set_title("Connect to Player")
+display.set_title("Waiting on Host...")
 
 while True:
     # --- Player Connection ---
     if player.connected and not had_stations:
-        display.set_title("Player connected!")
+        display.set_title("Host Connected!")
         display.refresh()
         player.request_stations()
     elif not player.connected:
         if had_stations:
             keys.set_stations([])
-            display.set_title("Player disconnected!")
+            display.set_title("Host Disconnected!")
             player.flush_buffer()
             had_stations = False
 
@@ -66,6 +66,8 @@ while True:
             had_stations = True
         elif event_name == "station_playing":
             keys.set_playing_station(data)
+        elif event_name == "status":
+            display.set_title(str(data))
 
     # --- Encoder Rotation ---
     position = macropad.encoder

--- a/player/src/lib/client_macropad.py
+++ b/player/src/lib/client_macropad.py
@@ -30,6 +30,25 @@ logger = logging.getLogger("MACROPAD")
 DATA_INTERFACE_NAME = "CircuitPython CDC2"
 
 
+def notify_status(message: str):
+    """Send a status message synchronously to the Macropad if connected."""
+    import json
+    import serial
+
+    macropad_ports = [
+        port.device
+        for port in serial.tools.list_ports.comports()
+        if port.interface and port.interface.startswith(DATA_INTERFACE_NAME)
+    ]
+    if macropad_ports:
+        try:
+            with serial.Serial(macropad_ports[0], baudrate=115200, timeout=0.1) as ser:
+                msg = json.dumps({"event": "status", "data": message})
+                ser.write((msg + "\n").encode())
+        except Exception as e:
+            logger.warning("Failed to notify macropad status: %s", e)
+
+
 class MacropadClient(RadioPadClient):
     def __init__(self, player: RadioPadPlayer):
         super().__init__(player)

--- a/player/src/lib/config.py
+++ b/player/src/lib/config.py
@@ -33,13 +33,15 @@ def http_client_headers(custom_headers=None):
     return {**defaults, **custom_headers}
 
 
-async def fetch_json_url(url, timeout=12, retries=3):
+async def fetch_json_url(url, timeout=12, retries=3, on_status=None):
     """Fetch JSON from URL with retries"""
     headers = http_client_headers({"Accept": "application/json"})
     async with httpx.AsyncClient(
         timeout=timeout, headers=headers, follow_redirects=True
     ) as client:
         for attempt in range(retries):
+            if on_status and attempt == 0:
+                on_status("Fetching registry...")
             try:
                 response = await client.get(url)
                 if response.status_code == 200:
@@ -54,6 +56,8 @@ async def fetch_json_url(url, timeout=12, retries=3):
                 logger.warning("Attempt %s failed for %s: %s", attempt + 1, url, e)
             if attempt < retries - 1:
                 logger.info("Retrying in %s seconds...", 2**attempt)
+                if on_status:
+                    on_status(f"Net error, retry {attempt + 1}")
                 await asyncio.sleep(2**attempt)
     return None
 
@@ -64,14 +68,17 @@ async def make(
     stations_url=None,
     switchboard_url=None,
     enable_discovery=True,
+    on_status=None,
 ):
     """
     Create a RadioPadPlayerConfig object with the provided parameters.
     If enable_discovery is True, attempt to discover missing configuration from the registry.
     """
     if enable_discovery:
+        if on_status:
+            on_status("Discovering player...")
         stations_url, switchboard_url = await discover_config(
-            player, registry_url, stations_url, switchboard_url
+            player, registry_url, stations_url, switchboard_url, on_status=on_status
         )
 
     if not stations_url:
@@ -82,7 +89,9 @@ async def make(
     logger.info("Using stations_url: %s", stations_url)
     logger.info("Using switchboard_url: %s", switchboard_url)
 
-    station_data = await fetch_json_url(stations_url)
+    if on_status:
+        on_status("Fetching stations...")
+    station_data = await fetch_json_url(stations_url, on_status=on_status)
     if not station_data:
         raise ConfigError("Failed fetching stations")
     if (
@@ -105,7 +114,7 @@ async def make(
 
 
 async def discover_config(
-    player, registry_url, stations_url=None, switchboard_url=None
+    player, registry_url, stations_url=None, switchboard_url=None, on_status=None
 ):
     """Discover missing player configuration from the registry."""
 
@@ -121,7 +130,7 @@ async def discover_config(
     url = f"{registry_url.rstrip('/')}/accounts/{account_id}/players/{player_id}"
     logger.info("Discovering configuration from %s ...", url)
     logger.info("  To skip, set RADIOPAD_ENABLE_DISCOVERY=false")
-    data = await fetch_json_url(url)
+    data = await fetch_json_url(url, on_status=on_status)
 
     if data:
         stations_url = stations_url or data.get("stations_url")

--- a/player/src/player.py
+++ b/player/src/player.py
@@ -25,7 +25,7 @@ import signal
 import sys
 
 import lib.config as config
-from lib.client_macropad import MacropadClient
+from lib.client_macropad import MacropadClient, notify_status
 from lib.client_switchboard import SwitchboardClient
 from lib.exceptions import ConfigError
 from lib.health import DEFAULT_HEALTH_PATH, clear_health, mark_healthy
@@ -79,6 +79,7 @@ if __name__ == "__main__":
     clear_health(health_path)
     player = None
     try:
+        notify_status("Starting player...")
         # Load configuration
         player_config = asyncio.run(
             config.make(
@@ -90,6 +91,7 @@ if __name__ == "__main__":
                 switchboard_url=os.getenv("RADIOPAD_SWITCHBOARD_URL", None),
                 enable_discovery=os.getenv("RADIOPAD_ENABLE_DISCOVERY", "true").lower()
                 == "true",
+                on_status=notify_status,
             )
         )
 
@@ -102,12 +104,23 @@ if __name__ == "__main__":
             ),
         )
         player.register_client(MacropadClient(player))
+        def handle_disconnect():
+            clear_health(health_path)
+            notify_status("Registry offline")
+
+        def handle_connect():
+            mark_healthy(health_path)
+            if player.station:
+                notify_status(player.station.name)
+            else:
+                notify_status("Registry connected")
+
         if player.config.switchboard_url:
             player.register_client(
                 SwitchboardClient(
                     player,
-                    on_connect=lambda: mark_healthy(health_path),
-                    on_disconnect=lambda: clear_health(health_path),
+                    on_connect=handle_connect,
+                    on_disconnect=handle_disconnect,
                 )
             )
         else:


### PR DESCRIPTION
Improves how connection, network, and registry issues are surfaced on the macropad. Introduces a status event, clearer connection jargon, synchronous status notify in player, and surfacing switchboard/registry errors.