### PR TITLE
feat: surface player status on macropad display

### DIFF
--- a/macropad-control/src/main.py
+++ b/macropad-control/src/main.py
@@ -66,6 +66,8 @@ while True:
             had_stations = True
         elif event_name == "station_playing":
             keys.set_playing_station(data)
+        elif event_name == "status":
+            display.set_title(str(data))
 
     # --- Encoder Rotation ---
     position = macropad.encoder

--- a/player/src/lib/client_switchboard.py
+++ b/player/src/lib/client_switchboard.py
@@ -72,6 +72,7 @@ class SwitchboardClient(RadioPadClient):
                 self._connected = True
                 if self.on_connect:
                     self.on_connect()
+                await self.broadcast("status", data="Switchboard connected")
                 asyncio.create_task(self.broadcast("station_playing"))
                 async for msg in ws:
                     await self.handle_message(msg)
@@ -88,6 +89,7 @@ class SwitchboardClient(RadioPadClient):
                 self.ws = None
                 if self._connected:
                     self._connected = False
+                    await self.broadcast("status", data="Switchboard offline")
                     if self.on_disconnect:
                         self.on_disconnect()
 

--- a/player/src/lib/interfaces.py
+++ b/player/src/lib/interfaces.py
@@ -81,6 +81,15 @@ class RadioPadPlayer(abc.ABC):
         """Register a client with this player."""
         self._clients.append(client)
 
+    async def broadcast_status(self, message: str):
+        """Broadcast a status message to all connected clients."""
+        payload = json.dumps({"event": "status", "data": message})
+        for client in self._clients:
+            try:
+                await client._send(payload)
+            except Exception as e:
+                logger.error("Status broadcast error for %s: %s", client, e)
+
     @abc.abstractmethod
     async def play(self, station: RadioPadStation):
         """Play a radio station."""
@@ -109,7 +118,7 @@ class RadioPadClient(abc.ABC):
         self.register_event("volume", self._handle_volume)
         self.register_event("station_request", self._handle_station_request)
         # Ignored events
-        for ignored in ("station_playing", "client_count", "stations_url"):
+        for ignored in ("station_playing", "client_count", "stations_url", "status"):
             self.register_event(ignored, self._handle_ignored)
 
     @property

--- a/player/src/lib/player_mpv.py
+++ b/player/src/lib/player_mpv.py
@@ -79,10 +79,12 @@ class MpvPlayer(RadioPadPlayer):
                 self.station = station
             else:
                 logger.error("failed to start mpv process.")
+                await self.broadcast_status("Playback failed")
             self.mpv_sock = None
             await self._establish_ipc_socket()
         except Exception as e:
             logger.error("error starting station: %s", e, exc_info=True)
+            await self.broadcast_status("Playback error")
 
     async def stop(self):
         """Stop playback of the current station."""


### PR DESCRIPTION
## Problem

During a registry outage, the macropad display showed "Connect to Player" — misleading because the macropad *was* connected to the player via USB. The player was experiencing backend issues (switchboard offline, registry unreachable) but had no way to communicate that to the macropad.

## Solution

Add a `status` event to the player→macropad serial protocol. The player now broadcasts status messages that the macropad displays on its title bar:

| Event source | Message | When |
|---|---|---|
| Switchboard client | `Switchboard connected` | WebSocket connects |
| Switchboard client | `Switchboard offline` | WebSocket disconnects |
| mpv player | `Playback failed` | mpv process fails to start |
| mpv player | `Playback error` | Exception during play |

### Changes

**Player (`player/src/lib/`)**
- `interfaces.py`: Add `broadcast_status()` on `RadioPadPlayer` so the player (not just clients) can push status to all clients. Add `status` to ignored events list so clients don't warn on their own broadcasts.
- `client_switchboard.py`: Broadcast status on connect and disconnect.
- `player_mpv.py`: Broadcast status on playback failures.

**Macropad (`macropad-control/src/`)**
- `main.py`: Handle `status` event by updating the display title bar.

### Behavior

Status messages are transient — the next `station_playing` event or page switch naturally overwrites them. This means:
- "Switchboard connected" flashes briefly then shows the station name
- "Switchboard offline" persists until reconnection or user interaction
- "Playback failed" persists until next successful play