### PR TITLE
feat: macropad tooling — compose overlay, bin scripts & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,28 @@ bin/ci
 COMPOSE_FILE=compose.split.yaml bin/ci
 ```
 
+### Local macropad testing
+
+If you change the macropad firmware in [`macropad-control`](./macropad-control/), sync it to the device first:
+
+```sh
+cd macropad-control
+bin/refresh
+```
+
+The default compose files do not expose host USB serial devices to the `player` container. For end-to-end testing with a real macropad attached, layer in the macropad overlay:
+
+```sh
+# determine the macropad serial port
+macropad-control/bin/status
+
+# start with macropad overlay
+RADIOPAD_MACROPAD_PORT=/dev/ttyACM1 \
+docker compose -f compose.yaml -f compose.macropad.yaml up
+```
+
+If `bin/status` shows no ports, the macropad is not visible to this Linux environment. In WSL2, the USB device must be attached via USB/IP first.
+
 ## Architecture
 
 ### Deployment modes

--- a/compose.macropad.yaml
+++ b/compose.macropad.yaml
@@ -1,0 +1,7 @@
+services:
+  player:
+    user: root
+    environment:
+      RADIOPAD_MACROPAD_PORT: "${RADIOPAD_MACROPAD_PORT:-/dev/ttyACM1}"
+    devices:
+      - "${RADIOPAD_MACROPAD_PORT:-/dev/ttyACM1}:${RADIOPAD_MACROPAD_PORT:-/dev/ttyACM1}"

--- a/macropad-control/README.md
+++ b/macropad-control/README.md
@@ -34,6 +34,12 @@ A linux host is assumed, with the macropad plugged into it. It must have python3
    bin/mount
    ```
 
+   To inspect detected devices without mounting, run:
+
+   ```sh
+   bin/status
+   ```
+
 2. **Customize button colors and behavior:**
    - Edit [`src/main.py`](./src/main.py) to change macropad key behavior.
    - Stations are received from the connected [player](../player/), which loads them from a registry [station preset](../player/README.md#registry-discovery).
@@ -43,6 +49,8 @@ A linux host is assumed, with the macropad plugged into it. It must have python3
    bin/refresh
    ```
 
+   `bin/refresh` will automatically run `bin/mount` if the CIRCUITPY volume is not mounted yet.
+
 4. **Debug via the USB serial console**
 
 Attaching to the console allows you to read stdout/stderr, for instance to view exceptions or debug messages.
@@ -51,7 +59,16 @@ Attaching to the console allows you to read stdout/stderr, for instance to view 
   bin/console
   ```
 
-  > this command requires that the executing user has access to /dev/ttyACM* devices, which are owned by the `uucp` group in archlinux.
+  The player uses the CircuitPython `CDC2` port for commands and events, while `bin/console` targets the primary CircuitPython console port.
+
+  > Serial access requires that the executing user has access to `/dev/ttyACM*` devices, which are owned by the `uucp` group in archlinux.
+
+### WSL Notes
+
+In WSL2, the macropad needs to be attached into Linux with USB/IP before the storage and `/dev/ttyACM*` devices appear. Once attached, this project expects:
+
+- player data port: `/dev/ttyACM1` (`CircuitPython CDC2`)
+- console port: `/dev/ttyACM0` (`CircuitPython CDC`)
 
 ## Development
 

--- a/macropad-control/bin/console
+++ b/macropad-control/bin/console
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
-dev=$(find /dev/serial/by-id/ -type l -name '*Macropad*' | sort | head -n1)
-if [ -z "$dev" ]; then
-  echo "No Macropad device found."
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./libmacropad
+source "$SCRIPT_DIR/libmacropad"
+
+dev="$(find_macropad_console_port 2>/dev/null || true)"
+[ -n "$dev" ] || dev="$(find /dev/serial/by-id/ -type l -name '*Macropad*' 2>/dev/null | sort | head -n1)"
+[ -n "$dev" ] || {
+  echo "No Macropad console port found." >&2
+  echo "Try 'bin/status' to inspect detected storage and serial ports." >&2
   exit 1
-fi
+}
+
+echo "[info] opening console on $dev"
 
 screen "$dev" 115200

--- a/macropad-control/bin/libmacropad
+++ b/macropad-control/bin/libmacropad
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+macropad_mount_target() {
+  echo "${RADIOPAD_MACROPAD_MOUNT:-/mnt/CIRCUITPY}"
+}
+
+find_circuitpy_block_device() {
+  if [ -n "${RADIOPAD_MACROPAD_DISK:-}" ]; then
+    echo "$RADIOPAD_MACROPAD_DISK"
+    return 0
+  fi
+
+  if [ -e /dev/disk/by-label/CIRCUITPY ]; then
+    readlink -f /dev/disk/by-label/CIRCUITPY
+    return 0
+  fi
+
+  if command -v lsblk >/dev/null 2>&1; then
+    local disk
+    disk="$(lsblk -pnro PATH,LABEL | awk '$2=="CIRCUITPY"{print $1; exit}')"
+    if [ -n "$disk" ]; then
+      echo "$disk"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+find_macropad_port_by_prefix() {
+  local prefix="$1"
+  local interface_file
+
+  for interface_file in /sys/class/tty/ttyACM*/device/interface /sys/class/tty/ttyUSB*/device/interface; do
+    [ -e "$interface_file" ] || continue
+
+    if grep -q "^${prefix}" "$interface_file"; then
+      basename "$(dirname "$(dirname "$interface_file")")"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+find_macropad_data_port() {
+  if [ -n "${RADIOPAD_MACROPAD_PORT:-}" ]; then
+    echo "$RADIOPAD_MACROPAD_PORT"
+    return 0
+  fi
+
+  local tty_name
+  tty_name="$(find_macropad_port_by_prefix "CircuitPython CDC2")" || return 1
+  echo "/dev/${tty_name}"
+}
+
+find_macropad_console_port() {
+  if [ -n "${RADIOPAD_MACROPAD_CONSOLE_PORT:-}" ]; then
+    echo "$RADIOPAD_MACROPAD_CONSOLE_PORT"
+    return 0
+  fi
+
+  local tty_name
+  tty_name="$(find_macropad_port_by_prefix "CircuitPython CDC control")" || return 1
+  echo "/dev/${tty_name}"
+}

--- a/macropad-control/bin/mount
+++ b/macropad-control/bin/mount
@@ -1,10 +1,28 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-my_id=$(id -u)
-disk="/dev/disk/by-label/CIRCUITPY"
-target="/mnt/CIRCUITPY"
-[ -d "$target" ] || sudo mkdir -p "$target"
-sudo umount "$target" || true
-sudo mount "$disk" "$target" -o uid="$my_id" -o rw
-echo "[ok] mounted disk to /mnt/CIRCUITPY under uid $my_id"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./libmacropad
+source "$SCRIPT_DIR/libmacropad"
+
+my_id="$(id -u)"
+target="$(macropad_mount_target)"
+disk="$(find_circuitpy_block_device)" || {
+  echo "No CIRCUITPY block device found. Is the macropad storage exposed to this Linux environment?" >&2
+  exit 1
+}
+
+if [ "$EUID" -eq 0 ]; then
+  SUDO=()
+else
+  SUDO=(sudo)
+fi
+
+[ -d "$target" ] || "${SUDO[@]}" mkdir -p "$target"
+
+if mountpoint -q "$target" 2>/dev/null; then
+  "${SUDO[@]}" umount "$target"
+fi
+
+"${SUDO[@]}" mount "$disk" "$target" -o uid="$my_id",rw
+echo "[ok] mounted $disk to $target under uid $my_id"

--- a/macropad-control/bin/refresh
+++ b/macropad-control/bin/refresh
@@ -1,19 +1,25 @@
 #!/usr/bin/env bash
 set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(git rev-parse --show-toplevel)/macropad-control"
+# shellcheck source=./libmacropad
+source "$SCRIPT_DIR/libmacropad"
 
-mount | grep -q /mnt/CIRCUITPY || {
-  echo "macropad not mounted, please run bin/mount and try again." >&2
-  exit 1
-}
+target="$(macropad_mount_target)"
 
-cd /mnt/CIRCUITPY/
+if ! mountpoint -q "$target" 2>/dev/null; then
+  echo "[info] macropad not mounted, attempting bin/mount"
+  "$SCRIPT_DIR/mount"
+fi
+
+cd "$target"
 
 if [ "${1:-}" = "--hard" ]; then
   echo "removing existing files"
   rm -rf ./*
 fi
 
-cp -r "$PROJECT_ROOT"/src/* .
+cp -r "$PROJECT_ROOT"/src/. .
 sync
-echo "[ok] copied files"
+echo "[ok] copied files to $target"

--- a/macropad-control/bin/status
+++ b/macropad-control/bin/status
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./libmacropad
+source "$SCRIPT_DIR/libmacropad"
+
+target="$(macropad_mount_target)"
+
+echo "mount target: $target"
+if mountpoint -q "$target" 2>/dev/null; then
+  echo "storage: mounted"
+else
+  echo "storage: not mounted"
+fi
+
+if disk="$(find_circuitpy_block_device 2>/dev/null)"; then
+  echo "storage device: $disk"
+else
+  echo "storage device: not found"
+fi
+
+if console_port="$(find_macropad_console_port 2>/dev/null)"; then
+  echo "console port: $console_port"
+else
+  echo "console port: not found"
+fi
+
+if data_port="$(find_macropad_data_port 2>/dev/null)"; then
+  echo "player data port: $data_port"
+else
+  echo "player data port: not found"
+fi

--- a/player/README.md
+++ b/player/README.md
@@ -42,6 +42,7 @@ name | description | default
 `RADIOPAD_ENABLE_DISCOVERY` | Enables discovery based on RADIOPAD_PLAYER_ID. Anything other than "true" will disable. | `true`
 `RADIOPAD_MPV_SOCKET_PATH` | Path to the mpv IPC socket. | `/tmp/radio-pad-mpv.sock`
 `RADIOPAD_HEALTH_PATH` | Path to the player readiness file used by the container healthcheck. | `/tmp/radio-pad-ready`
+`RADIOPAD_MACROPAD_PORT` | Explicit serial device path for the macropad USB data port. Useful in containers where auto-discovery metadata is missing. | `None`
 `RADIOPAD_PLAYER` | Name of player in `{account_id}/{player_id}` format, used for [registry discovery](#registry-discovery). | `briceburg/living-room`
 `RADIOPAD_REGISTRY_URL` | Registry URL for [discovery](#registry-discovery). | `https://registry.radiopad.dev/api`
 `RADIOPAD_STATIONS_URL` | URL returning a station preset JSON object. Discovered from the registry if not set. | `None`
@@ -90,6 +91,25 @@ options snd-usb-audio index=0,1 vid=0x041e,0x239a pid=0x324d,0x8108
 ## Development
 
 For compose-based development with all services, see the [root README](../README.md#development).
+
+For containerized testing with a real macropad attached, determine the device path first:
+
+```sh
+python -m serial.tools.list_ports -v
+
+# or from the repo root:
+macropad-control/bin/status
+
+# or, on a typical Linux host:
+ls -l /dev/ttyACM* /dev/ttyUSB*
+```
+
+Then pass the device through to the player service:
+
+```sh
+RADIOPAD_MACROPAD_PORT=/dev/ttyACM1 \
+docker compose -f compose.yaml -f compose.macropad.yaml up player
+```
 
 ### Contributing
 

--- a/player/src/lib/client_macropad.py
+++ b/player/src/lib/client_macropad.py
@@ -19,6 +19,7 @@
 
 import asyncio
 import logging
+import os
 
 import serial.tools.list_ports
 import serial_asyncio
@@ -60,18 +61,28 @@ class MacropadClient(RadioPadClient):
             logger.info("reconnecting in 3s...")
             await asyncio.sleep(3)
 
-    async def _connect(self):
-        macropad_ports = [
+    def _candidate_ports(self):
+        configured_port = os.getenv("RADIOPAD_MACROPAD_PORT")
+        if configured_port:
+            return [configured_port]
+
+        return [
             port.device
             for port in serial.tools.list_ports.comports()
             if port.interface and port.interface.startswith(DATA_INTERFACE_NAME)
         ]
 
+    async def _connect(self):
+        macropad_ports = self._candidate_ports()
+
         if not macropad_ports:
             logger.warning("no data ports found, is it plugged in?")
             return None, None
 
-        logger.info("found ports: %s", macropad_ports)
+        if os.getenv("RADIOPAD_MACROPAD_PORT"):
+            logger.info("using configured macropad port: %s", macropad_ports[0])
+        else:
+            logger.info("found ports: %s", macropad_ports)
         for macropad_port in macropad_ports:
             logger.info("attempting to connect to %s", macropad_port)
             try:


### PR DESCRIPTION
## PR 0: Macropad tooling

Enables local macropad testing with the containerized stack. This is the first PR in the [macropad status unification](https://github.com/briceburg/radio-pad/tree/feat/macropad-status-unification) decomposition — independent of all other PRs and unblocks hardware testing.

### Changes

**Infrastructure**
- `compose.macropad.yaml`: USB device overlay — passes host serial device to player container (`-f compose.macropad.yaml`)

**macropad-control/bin**
- `libmacropad`: Shared shell helpers for CIRCUITPY block device, CDC2 data port, and CDC console port discovery. Supports env var overrides (`RADIOPAD_MACROPAD_PORT`, `RADIOPAD_MACROPAD_DISK`, `RADIOPAD_MACROPAD_MOUNT`, `RADIOPAD_MACROPAD_CONSOLE_PORT`)
- `bin/status`: New diagnostic script showing mount state, storage device, and serial ports
- `bin/console`: Refactored to use libmacropad
- `bin/mount`: Refactored — auto-discovers block device, conditional sudo, libmacropad
- `bin/refresh`: Refactored — auto-mount if not mounted, configurable target, libmacropad

**Player**
- `client_macropad.py`: Add `_candidate_ports()` method supporting `RADIOPAD_MACROPAD_PORT` env var for containerized environments where USB metadata is unavailable for auto-discovery

**Docs**
- Scoped updates to macropad-control, player, and root READMEs documenting the new tooling, WSL notes, and containerized testing workflow

### Design notes
- Player runs as root in the compose overlay to access USB devices (dev-only; documented)
- Default device path (`/dev/ttyACM1`) is a fallback — auto-discovery via `_candidate_ports()` is primary
- `bin/refresh` auto-mount is a convenience; logs an `[info]` message when it does so