### PR TITLE
feat: switchboard flexible auth — skip token check when auth disabled

### DIFF
--- a/registry/src/switchboard/switchboard.py
+++ b/registry/src/switchboard/switchboard.py
@@ -12,6 +12,11 @@ logger = logging.getLogger("switchboard")
 PLAYER_USER_AGENT_PREFIX = "RadioPad/"
 
 
+def controller_auth_required(websocket: WebSocket) -> bool:
+    auth = getattr(websocket.app.state, "auth", None)
+    return auth is not None and getattr(auth, "enabled", False)
+
+
 async def publish_event(broadcast: Broadcast, channel: str, event: str, data: object) -> None:
     message = json.dumps({"event": event, "data": data})
     broadcast.set_state(channel, message)
@@ -70,7 +75,7 @@ async def websocket_endpoint(
 
     # Authenticate controllers
     if not is_player:
-        if not token:
+        if controller_auth_required(websocket) and not token:
             await websocket.close(code=4001, reason="Authentication token required")
             return
         try:

--- a/registry/tests/switchboard/test_switchboard.py
+++ b/registry/tests/switchboard/test_switchboard.py
@@ -41,11 +41,28 @@ def test_player_requires_stations_url_header(switchboard_client: TestClient) -> 
             pass
 
 
-def test_controller_rejected_without_token(switchboard_client: TestClient) -> None:
-    """Controller without a token is closed with 4001."""
-    with pytest.raises(WebSocketDisconnect):
-        with switchboard_client.websocket_connect("switchboard/acct/player1") as ws:
-            ws.receive_text()
+def test_controller_connects_without_token_when_auth_disabled(switchboard_client: TestClient) -> None:
+    """Controller can connect anonymously when auth is disabled."""
+    with switchboard_client.websocket_connect("switchboard/acct/player1") as ws:
+        ws.send_json({"event": "ping"})
+        resp = ws.receive_json()
+        assert resp["event"] == "pong"
+
+
+def test_controller_rejected_without_token_when_auth_enabled() -> None:
+    """Controller without a token is closed with 4001 when auth is enabled."""
+    app = create_app()
+
+    # Simulate auth being enabled by setting a mock AuthServices with enabled=True
+    class _FakeAuth:
+        enabled = True
+
+    app.state.auth = _FakeAuth()
+
+    with TestClient(app) as client:
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect("switchboard/acct/player1") as ws:
+                ws.receive_text()
 
 
 def test_player_connects_with_valid_headers(switchboard_client: TestClient) -> None:

--- a/tests/integration/test_switchboard.py
+++ b/tests/integration/test_switchboard.py
@@ -16,6 +16,14 @@ PLAYER_HEADERS = {
 }
 
 
+async def wait_for_event(ws, event_name, timeout=5):
+    """Read messages until the expected event arrives (or timeout)."""
+    while True:
+        message = json.loads(await asyncio.wait_for(ws.recv(), timeout=timeout))
+        if message.get("event") == event_name:
+            return message
+
+
 @pytest.mark.asyncio
 async def test_player_connect(switchboard_url):
     """Player can connect, send ping, receive pong."""
@@ -23,16 +31,17 @@ async def test_player_connect(switchboard_url):
         f"{switchboard_url}/test-acct/player1", additional_headers=PLAYER_HEADERS
     ) as ws:
         await ws.send(json.dumps({"event": "ping"}))
-        resp = json.loads(await asyncio.wait_for(ws.recv(), timeout=5))
+        resp = await wait_for_event(ws, "pong")
         assert resp["event"] == "pong"
 
 
 @pytest.mark.asyncio
-async def test_controller_rejected_without_token(switchboard_url):
-    """Controllers without an auth token are rejected."""
-    with pytest.raises(Exception):
-        async with websockets.connect(f"{switchboard_url}/test-acct/player1") as ws:
-            await asyncio.wait_for(ws.recv(), timeout=3)
+async def test_controller_connects_without_token_when_auth_disabled(switchboard_url):
+    """Controllers can connect anonymously when registry auth is disabled."""
+    async with websockets.connect(f"{switchboard_url}/test-acct/player1") as ws:
+        await ws.send(json.dumps({"event": "ping"}))
+        resp = await wait_for_event(ws, "pong")
+        assert resp["event"] == "pong"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## PR 1: Switchboard flexible auth + test utilities

Part of the [macropad status unification](https://github.com/briceburg/radio-pad/tree/feat/macropad-status-unification) decomposition. Independent of all other PRs.

### Problem

The switchboard unconditionally requires a token for controller WebSocket connections, even when OIDC auth is not configured. This breaks dev/integration environments where auth is intentionally disabled, and prevents the remote-control from connecting without a token in local development.

### Changes

**Registry** (`registry/src/switchboard/switchboard.py`)
- Add `controller_auth_required(websocket)` — checks `app.state.auth.enabled` to determine if token validation is needed
- When auth is disabled (no OIDC env vars), controllers connect anonymously
- When auth is enabled, behavior is unchanged — token is required

**Unit tests** (`registry/tests/switchboard/test_switchboard.py`)
- Rename `test_controller_rejected_without_token` → `test_controller_connects_without_token_when_auth_disabled` (reflects actual dev environment behavior)
- Add `test_controller_rejected_without_token_when_auth_enabled` with a mock `_FakeAuth(enabled=True)` to verify the auth-required path

**Integration tests** (`tests/integration/test_switchboard.py`)
- Add `wait_for_event(ws, event_name)` helper for reliable event-based assertions (drains intermediate messages)
- Update `test_player_connect` to use `wait_for_event`
- Replace `test_controller_rejected_without_token` with `test_controller_connects_without_token_when_auth_disabled` (integration env has no OIDC)

### Design notes

- `controller_auth_required` uses `getattr(websocket.app.state, "auth", None)` to safely handle the split-mode case where switchboard runs without the API profile (and `app.state.auth` is never set)
- Default-secure: when auth IS configured, the existing token-required behavior is preserved