### PR TITLE
feat: player SwitchboardClient reconnect resilience

### DIFF
--- a/player/pyproject.toml
+++ b/player/pyproject.toml
@@ -9,3 +9,7 @@ description = "Radio-Pad player client"
 
 [tool.isort]
 profile = "black"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/player/src/lib/client_switchboard.py
+++ b/player/src/lib/client_switchboard.py
@@ -19,6 +19,7 @@
 
 import asyncio
 import logging
+import random
 from collections.abc import Callable
 
 import websockets
@@ -29,6 +30,27 @@ from lib.interfaces import RadioPadClient, RadioPadPlayer
 logger = logging.getLogger("SWITCHBOARD")
 
 MPV_SOCKET_FILE = "/tmp/radio-pad-mpv.sock"
+SWITCHBOARD_CONNECT_TIMEOUT_SECONDS = 5
+SWITCHBOARD_RETRY_INITIAL_DELAY_SECONDS = 1
+SWITCHBOARD_RETRY_FACTOR = 1.5
+SWITCHBOARD_RETRY_JITTER_SECONDS = 1
+SWITCHBOARD_RETRY_MAX_DELAY_SECONDS = 8
+
+
+def next_retry_delay(
+    retry_delay: float,
+    *,
+    factor: float = SWITCHBOARD_RETRY_FACTOR,
+    jitter_seconds: float = SWITCHBOARD_RETRY_JITTER_SECONDS,
+    max_delay_seconds: float = SWITCHBOARD_RETRY_MAX_DELAY_SECONDS,
+) -> tuple[float, float]:
+    """Return (sleep_seconds, next_delay) with exponential backoff + jitter."""
+    sleep_seconds = min(
+        retry_delay + (random.random() * jitter_seconds),
+        max_delay_seconds,
+    )
+    next_delay = min(retry_delay * factor, max_delay_seconds)
+    return sleep_seconds, next_delay
 
 
 class SwitchboardClient(RadioPadClient):
@@ -54,42 +76,46 @@ class SwitchboardClient(RadioPadClient):
             logger.info("skipping switchboard connection, url not provided.")
             return
 
+        retry_delay = SWITCHBOARD_RETRY_INITIAL_DELAY_SECONDS
         while True:
             try:
                 await self._connect_and_listen()
-            except Exception as e:
-                logger.error("Unexpected error: %s", e, exc_info=True)
-            logger.info("reconnecting to switchboard in 5s...")
-            await asyncio.sleep(5)
-
-    async def _connect_and_listen(self):
-        async for ws in websockets.connect(
-            self.url, additional_headers=self.http_headers
-        ):
-            try:
-                logger.info("connected to: %s", self.url)
-                self.ws = ws
-                self._connected = True
-                if self.on_connect:
-                    self.on_connect()
-                asyncio.create_task(self.broadcast("station_playing"))
-                async for msg in ws:
-                    await self.handle_message(msg)
-            except websockets.exceptions.ConnectionClosed:
-                # If the connection fails with a transient error, it is retried with exponential backoff. If it fails with a fatal error, the exception is raised, breaking out of the loop.
-                continue
-            except (ConnectionRefusedError, OSError) as e:
+                retry_delay = SWITCHBOARD_RETRY_INITIAL_DELAY_SECONDS
+            except asyncio.CancelledError:
+                raise
+            except (ConnectionRefusedError, TimeoutError, OSError) as e:
                 logger.warning("failed to connect to %s: %s", self.url, e)
                 logger.warning(
                     "If this is the wrong URL, please set the SWITCHBOARD_URL environment variable."
                 )
-                continue
-            finally:
-                self.ws = None
-                if self._connected:
-                    self._connected = False
-                    if self.on_disconnect:
-                        self.on_disconnect()
+            except websockets.exceptions.WebSocketException as e:
+                logger.warning("switchboard websocket error: %s", e)
+            except Exception as e:
+                logger.error("Unexpected error: %s", e, exc_info=True)
+
+            sleep_seconds, retry_delay = next_retry_delay(retry_delay)
+            logger.info("reconnecting to switchboard in %.1fs...", sleep_seconds)
+            await asyncio.sleep(sleep_seconds)
+
+    async def _connect_and_listen(self):
+        async with websockets.connect(
+            self.url,
+            additional_headers=self.http_headers,
+            open_timeout=SWITCHBOARD_CONNECT_TIMEOUT_SECONDS,
+        ) as ws:
+            logger.info("connected to: %s", self.url)
+            self.ws = ws
+            self._connected = True
+            if self.on_connect:
+                self.on_connect()
+            asyncio.create_task(self.broadcast("station_playing"))
+            async for msg in ws:
+                await self.handle_message(msg)
+        self.ws = None
+        if self._connected:
+            self._connected = False
+            if self.on_disconnect:
+                self.on_disconnect()
 
     async def _send(self, message):
         """Send a message to the macropad or switchboard."""

--- a/player/tests/test_client_switchboard.py
+++ b/player/tests/test_client_switchboard.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from lib.client_switchboard import next_retry_delay
+
+
+def test_next_retry_delay_adds_bounded_jitter_and_grows_delay():
+    with patch("lib.client_switchboard.random.random", return_value=0.5):
+        sleep_seconds, next_delay = next_retry_delay(
+            1,
+            factor=1.5,
+            jitter_seconds=1,
+            max_delay_seconds=8,
+        )
+
+    assert sleep_seconds == 1.5
+    assert next_delay == 1.5
+
+
+def test_next_retry_delay_caps_sleep_and_next_delay():
+    with patch("lib.client_switchboard.random.random", return_value=0.75):
+        sleep_seconds, next_delay = next_retry_delay(
+            8,
+            factor=1.5,
+            jitter_seconds=1,
+            max_delay_seconds=8,
+        )
+
+    assert sleep_seconds == 8
+    assert next_delay == 8


### PR DESCRIPTION
## PR 2: Player SwitchboardClient reconnect resilience

Part of the [macropad status unification](https://github.com/briceburg/radio-pad/tree/feat/macropad-status-unification) decomposition. Independent — no dependencies on other PRs.

### Problem

The SwitchboardClient uses a fixed 5-second retry and relies on `websockets.connect()`'s built-in async-for retry loop, which has unclear backoff behavior and catches errors broadly. Connection timeouts to unresponsive hosts can block indefinitely.

### Changes

**`player/src/lib/client_switchboard.py`**
- Add `next_retry_delay()` with exponential backoff + jitter (initial=1s, factor=1.5, jitter=1s, max=8s)
- Add `SWITCHBOARD_CONNECT_TIMEOUT_SECONDS = 5` via `open_timeout`
- Replace `websockets.connect()` async-for retry loop with explicit `async with` + outer while-loop
- Catch specific exception types: `CancelledError` (re-raise), `ConnectionRefusedError`/`TimeoutError`/`OSError`, `WebSocketException`, generic `Exception`
- Reset retry delay on successful connection

**`player/pyproject.toml`**
- Add `[tool.pytest.ini_options]` with `pythonpath` and `testpaths` so `bin/ci` can discover and run tests

**`player/tests/test_client_switchboard.py`** (new)
- Test `next_retry_delay` jitter+growth behavior
- Test delay capping at max

### Design notes

- The backoff constants (1s initial, 1.5x factor, 1s jitter, 8s max) give: ~1.5s, ~2.8s, ~4.5s, ~6.8s, ~8s, ~8s... — fast initial recovery with reasonable ceiling
- `CancelledError` is explicitly re-raised to support clean task cancellation (important for the TaskGroup refactor in PR 3)
- The `status_reporter` callback for surfacing connection state to the macropad is deferred to PR 3