### PR TITLE
feat: player→macropad status protocol + heartbeat

### DIFF
--- a/player/src/lib/client_macropad.py
+++ b/player/src/lib/client_macropad.py
@@ -18,6 +18,7 @@
 
 
 import asyncio
+import json
 import logging
 
 import serial.tools.list_ports
@@ -28,6 +29,7 @@ from lib.interfaces import RadioPadClient, RadioPadPlayer
 logger = logging.getLogger("MACROPAD")
 
 DATA_INTERFACE_NAME = "CircuitPython CDC2"
+HEARTBEAT_INTERVAL_SECONDS = 2
 
 
 class MacropadClient(RadioPadClient):
@@ -35,6 +37,7 @@ class MacropadClient(RadioPadClient):
         super().__init__(player)
         self.writer = None
         self.reader = None
+        self._status_by_scope = {}
 
         # Override station_list handler
         self.register_event("station_list", self._handle_station_list)
@@ -100,8 +103,11 @@ class MacropadClient(RadioPadClient):
         except asyncio.TimeoutError:
             pass  # Ignore timeout
 
-        # Listen for new messages
-        await self._listen()
+        await self.resend_status()
+
+        async with asyncio.TaskGroup() as task_group:
+            task_group.create_task(self._heartbeat_loop())
+            task_group.create_task(self._listen())
 
     async def _listen(self):
         buffer = ""
@@ -129,11 +135,44 @@ class MacropadClient(RadioPadClient):
             except Exception as e:
                 logger.error("Failed to send: %s", e)
 
+    async def _heartbeat_loop(self):
+        while self.writer:
+            await self._send(json.dumps({"event": "player_heartbeat", "data": None}))
+            await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+
+    async def publish_status(self, scope, summary):
+        if not isinstance(scope, str) or not scope:
+            logger.warning("ignoring invalid macropad status scope: %r", scope)
+            return
+
+        self._status_by_scope[scope] = summary if isinstance(summary, str) else ""
+        await self.resend_status(scope=scope)
+
+    async def resend_status(self, scope=None):
+        if not self.writer:
+            return
+
+        scopes = [scope] if scope else list(self._status_by_scope.keys())
+        for status_scope in scopes:
+            await self._send(
+                json.dumps(
+                    {
+                        "event": "player_status",
+                        "data": {
+                            "scope": status_scope,
+                            "summary": self._status_by_scope.get(status_scope, ""),
+                        },
+                    }
+                )
+            )
+
     async def _handle_station_list(self, event):
         station_list = [station.name for station in self.player.config.stations]
         await self.broadcast("station_list", data=station_list, limit_to_self=True)
         await asyncio.sleep(0.1)  # Handle backpressure
         await self.broadcast("station_playing")
+        await asyncio.sleep(0.1)
+        await self.resend_status()
 
     async def close(self):
         if self.writer:

--- a/player/src/lib/client_switchboard.py
+++ b/player/src/lib/client_switchboard.py
@@ -20,7 +20,7 @@
 import asyncio
 import logging
 import random
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 import websockets
 
@@ -59,12 +59,14 @@ class SwitchboardClient(RadioPadClient):
         player: RadioPadPlayer,
         on_connect: Callable[[], None] | None = None,
         on_disconnect: Callable[[], None] | None = None,
+        status_reporter: Callable[[str | None], Awaitable[None]] | None = None,
     ):
         super().__init__(player)
         self.url = player.config.switchboard_url
         self.ws = None
         self.on_connect = on_connect
         self.on_disconnect = on_disconnect
+        self.status_reporter = status_reporter
         self._connected = False
 
         self.http_headers = http_client_headers(
@@ -88,8 +90,10 @@ class SwitchboardClient(RadioPadClient):
                 logger.warning(
                     "If this is the wrong URL, please set the SWITCHBOARD_URL environment variable."
                 )
+                await self._report_status(self._status_summary(e))
             except websockets.exceptions.WebSocketException as e:
                 logger.warning("switchboard websocket error: %s", e)
+                await self._report_status(self._status_summary(e))
             except Exception as e:
                 logger.error("Unexpected error: %s", e, exc_info=True)
 
@@ -108,12 +112,14 @@ class SwitchboardClient(RadioPadClient):
             self._connected = True
             if self.on_connect:
                 self.on_connect()
+            await self._report_status(None)
             asyncio.create_task(self.broadcast("station_playing"))
             async for msg in ws:
                 await self.handle_message(msg)
         self.ws = None
         if self._connected:
             self._connected = False
+            await self._report_status("Switchboard down")
             if self.on_disconnect:
                 self.on_disconnect()
 
@@ -121,6 +127,17 @@ class SwitchboardClient(RadioPadClient):
         """Send a message to the macropad or switchboard."""
         if self.ws:
             await self.ws.send(message)
+
+    async def _report_status(self, summary):
+        if self.status_reporter:
+            await self.status_reporter(summary)
+
+    def _status_summary(self, error: Exception) -> str:
+        if isinstance(error, ConnectionRefusedError):
+            return "Switchboard down"
+        if isinstance(error, TimeoutError):
+            return "Network timeout"
+        return "Network issue"
 
     async def close(self):
         if self.ws:

--- a/player/src/lib/interfaces.py
+++ b/player/src/lib/interfaces.py
@@ -83,7 +83,7 @@ class RadioPadPlayer(abc.ABC):
 
     @abc.abstractmethod
     async def play(self, station: RadioPadStation):
-        """Play a radio station."""
+        """Play a radio station and return True when playback starts."""
 
     @abc.abstractmethod
     async def stop(self):
@@ -166,9 +166,11 @@ class RadioPadClient(abc.ABC):
                 (s for s in self.player.config.stations if s.name == data), None
             )
             if station:
-                await self.player.play(station)
+                if not await self.player.play(station):
+                    return
             else:
                 logger.warning("Station '%s' not found in RADIO_STATIONS.", data)
+                return
         else:
             await self.player.stop()
         await self.broadcast("station_playing")

--- a/player/src/lib/player_mpv.py
+++ b/player/src/lib/player_mpv.py
@@ -21,6 +21,7 @@ import asyncio
 import logging
 import os
 import subprocess
+from collections.abc import Awaitable, Callable
 
 from python_mpv_jsonipc import MPV
 
@@ -39,13 +40,14 @@ class MpvPlayer(RadioPadPlayer):
         super().__init__(config)
         self.audio_channels = audio_channels
         self.socket_path = socket_path
+        self.status_reporter: Callable[[str | None], Awaitable[None]] | None = None
         self.mpv_process = None
         self.mpv_sock = None
         self.mpv_volume = None
         self.mpv_sock_lock = asyncio.Lock()
 
     async def play(self, station: RadioPadStation):
-        """Play a radio station."""
+        """Play a radio station and return True when playback starts."""
 
         logger.info("playing station %s (%s)", station.name, station.url)
         try:
@@ -77,16 +79,24 @@ class MpvPlayer(RadioPadPlayer):
             if self.mpv_process and self.mpv_process.poll() is None:
                 logger.info("mpv process started with PID %s", self.mpv_process.pid)
                 self.station = station
+                await self._report_status(None)
             else:
                 logger.error("failed to start mpv process.")
+                await self._report_status("Playback failed")
+                return False
             self.mpv_sock = None
             await self._establish_ipc_socket()
+            return True
         except Exception as e:
+            await self.stop()
             logger.error("error starting station: %s", e, exc_info=True)
+            await self._report_status("Playback error")
+            return False
 
     async def stop(self):
         """Stop playback of the current station."""
         self.station = None
+        await self._report_status(None)
         if self.mpv_sock:
             try:
                 self.mpv_sock.stop()
@@ -147,3 +157,7 @@ class MpvPlayer(RadioPadPlayer):
                     await asyncio.sleep(0.2)
             logger.error("failed to establish mpv IPC socket.")
             return
+
+    async def _report_status(self, summary):
+        if self.status_reporter:
+            await self.status_reporter(summary)

--- a/player/src/player.py
+++ b/player/src/player.py
@@ -44,17 +44,28 @@ async def cleanup(player):
             logger.error("Error closing client %s: %s", client.__class__.__name__, e)
 
 
+async def run_clients(player):
+    async with asyncio.TaskGroup() as task_group:
+        for client in player.clients:
+            task_group.create_task(
+                client.run(),
+                name=f"{client.__class__.__name__}.run",
+            )
+
+
 async def main(player):
     """Runs the main event loop for the radio-pad player."""
     try:
-        await asyncio.gather(*(client.run() for client in player.clients))
-
+        try:
+            await run_clients(player)
+        except* Exception as exc_group:
+            logger.critical("Unexpected error in main: %s", exc_group, exc_info=True)
+            raise
     except asyncio.CancelledError:
         logger.info("exiting...")
         await cleanup(player)
         raise
-    except Exception as e:
-        logger.critical("Unexpected error in main: %s", e, exc_info=True)
+    except Exception:
         await cleanup(player)
         raise
 
@@ -101,13 +112,23 @@ if __name__ == "__main__":
                 "RADIOPAD_MPV_SOCKET_PATH", "/tmp/radio-pad-mpv.sock"
             ),
         )
-        player.register_client(MacropadClient(player))
+        macropad_client = MacropadClient(player)
+
+        async def report_playback_status(summary):
+            await macropad_client.publish_status("playback", summary)
+
+        async def report_upstream_status(summary):
+            await macropad_client.publish_status("upstream", summary)
+
+        player.status_reporter = report_playback_status
+        player.register_client(macropad_client)
         if player.config.switchboard_url:
             player.register_client(
                 SwitchboardClient(
                     player,
                     on_connect=lambda: mark_healthy(health_path),
                     on_disconnect=lambda: clear_health(health_path),
+                    status_reporter=report_upstream_status,
                 )
             )
         else:

--- a/player/tests/test_client_macropad.py
+++ b/player/tests/test_client_macropad.py
@@ -1,0 +1,83 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+from lib.client_macropad import MacropadClient
+from lib.interfaces import RadioPadPlayer, RadioPadPlayerConfig
+
+
+class DummyPlayer(RadioPadPlayer):
+    async def play(self, station):
+        return True
+
+    async def stop(self):
+        return None
+
+    async def volume_up(self):
+        return None
+
+    async def volume_down(self):
+        return None
+
+
+def make_player():
+    return DummyPlayer(
+        RadioPadPlayerConfig(
+            id="briceburg/test-player",
+            stations_url="http://example.test/stations.json",
+            stations=[],
+        )
+    )
+
+
+def test_publish_status_sends_scoped_payload():
+    client = MacropadClient(make_player())
+    sent_messages = []
+
+    async def fake_send(message):
+        sent_messages.append(json.loads(message))
+
+    client.writer = object()
+    client._send = fake_send
+
+    asyncio.run(client.publish_status("upstream", None))
+
+    assert sent_messages == [
+        {
+            "event": "player_status",
+            "data": {"scope": "upstream", "summary": ""},
+        }
+    ]
+
+
+def test_publish_status_string_summary_preserved():
+    client = MacropadClient(make_player())
+    sent_messages = []
+
+    async def fake_send(message):
+        sent_messages.append(json.loads(message))
+
+    client.writer = object()
+    client._send = fake_send
+
+    asyncio.run(client.publish_status("playback", "Playback failed"))
+
+    assert sent_messages[0]["data"]["summary"] == "Playback failed"
+
+
+def test_resend_status_sends_all_scopes():
+    client = MacropadClient(make_player())
+    sent_messages = []
+
+    async def fake_send(message):
+        sent_messages.append(json.loads(message))
+
+    client.writer = object()
+    client._send = fake_send
+    client._status_by_scope = {"upstream": "Switchboard down", "playback": ""}
+
+    asyncio.run(client.resend_status())
+
+    assert len(sent_messages) == 2
+    scopes = {m["data"]["scope"] for m in sent_messages}
+    assert scopes == {"upstream", "playback"}


### PR DESCRIPTION
## PR 3: Player→Macropad status protocol

Part of the [macropad status unification](https://github.com/briceburg/radio-pad/tree/feat/macropad-status-unification) decomposition. **Depends on PR #63** (player reconnect backoff).

### Problem

The macropad has no way to detect whether the player is experiencing upstream issues (switchboard down, network timeout) or playback failures. It also cannot detect player-process death while USB remains connected.

### Changes

**`player/src/lib/client_macropad.py`**
- Add `publish_status(scope, summary)` / `resend_status()` with per-scope state tracking (`_status_by_scope` dict)
- Add `_heartbeat_loop()` sending `player_heartbeat` every 2s
- Use `asyncio.TaskGroup` for concurrent heartbeat + message listening
- Resend status on reconnect and after station list sync

**`player/src/lib/client_switchboard.py`**
- Add `status_reporter` callback parameter
- Add `_report_status()` and `_status_summary()` helpers
- Report upstream status on connect (None=ok), disconnect ("Switchboard down"), and errors ("Network timeout", "Network issue")

**`player/src/lib/player_mpv.py`**
- Add `status_reporter` attribute for playback status
- `play()` returns `True` on success, `False` on failure; reports "Playback failed" / "Playback error"
- `stop()` clears playback status
- Add `_report_status()` helper

**`player/src/lib/interfaces.py`**
- Update `play()` docstring to reflect bool return
- `_handle_station_request` skips broadcast on play failure

**`player/src/player.py`**
- Refactor `main()` to use `run_clients()` with `TaskGroup` (replaces `asyncio.gather`)
- Wire `report_playback_status` and `report_upstream_status` closures through `MacropadClient.publish_status()`

**Tests** (`player/tests/test_client_macropad.py`)
- Test scoped status payload serialization
- Test string summary preservation
- Test resend_status sends all scopes

### Protocol

```json
{"event": "player_status", "data": {"scope": "upstream", "summary": "Switchboard down"}}
{"event": "player_status", "data": {"scope": "playback", "summary": ""}}
{"event": "player_heartbeat", "data": null}
```

### Design notes

- **Heartbeat interval (2s)**: macropad timeout should be ~6-8s (2-3 missed beats) — configured in PR 4
- **Scoped status**: `upstream`/`playback` scopes allow the macropad to prioritize which issue to display
- **Status dict not pruned**: with only 2 known scopes this is acceptable
- **TaskGroup safety**: asyncio is single-threaded — heartbeat and listen won't interleave partial serial writes