### PR TITLE
feat(remote-control): registry sync resilience with retry

### DIFF
--- a/remote-control/src/js/actions/auth-actions.js
+++ b/remote-control/src/js/actions/auth-actions.js
@@ -20,8 +20,14 @@ import { authStore, patchStore } from "../store.js";
 import { toastDanger, toastSuccess, toastWarning } from "../notifications.js";
 
 export function createAuthActions({ auth, refreshAccountsForCurrentRegistry }) {
+  let hasSeenInitialState = false;
+
   auth.addEventListener("statechange", async (event) => {
     patchStore(authStore, event.detail);
+    if (!hasSeenInitialState) {
+      hasSeenInitialState = true;
+      return;
+    }
     await refreshAccountsForCurrentRegistry("auth_accounts");
   });
   auth.addEventListener("error", async (event) => {
@@ -40,14 +46,13 @@ export function createAuthActions({ auth, refreshAccountsForCurrentRegistry }) {
   }
 
   return {
-    signIn: () =>
-      safeAction(() => auth.signIn(), "⚠️ Failed starting sign-in."),
+    signIn: () => safeAction(() => auth.signIn(), "Failed starting sign-in."),
 
     async signOut() {
       await safeAction(async () => {
         await auth.signOut();
         toastSuccess("Signed out.");
-      }, "⚠️ Failed signing out.");
+      }, "Failed signing out.");
     },
 
     async copyToken() {
@@ -59,7 +64,7 @@ export function createAuthActions({ auth, refreshAccountsForCurrentRegistry }) {
       await safeAction(async () => {
         await navigator.clipboard.writeText(token);
         toastSuccess("Copied API test token.");
-      }, "⚠️ Failed copying API test token.");
+      }, "Failed copying API test token.");
     },
   };
 }

--- a/remote-control/src/js/actions/settings-actions.js
+++ b/remote-control/src/js/actions/settings-actions.js
@@ -22,8 +22,22 @@ import {
   discoverPlayers,
   discoverPresets,
 } from "../services/registry-discovery.js";
-import { preferencesStore, settingsUiStore } from "../store.js";
-import { toastDanger, toastRegistryFailure } from "../notifications.js";
+import {
+  patchStore,
+  preferencesStore,
+  registryStore,
+  settingsUiStore,
+} from "../store.js";
+import {
+  dismissRegistryUnavailableToast,
+  toastDanger,
+  toastRegistryUnavailable,
+} from "../notifications.js";
+import {
+  advanceRetryState,
+  createRetryState,
+  resetRetryState,
+} from "../utils/retry.js";
 
 export function createSettingsActions({
   prefs,
@@ -31,41 +45,65 @@ export function createSettingsActions({
   onPlayerSelected,
   onPresetSelected,
 }) {
+  const setRegistryPhase = (phase, errorText = "", extra = {}) => {
+    patchStore(registryStore, { phase, errorText, ...extra });
+  };
+  const retryState = createRetryState();
+
   let lastPlayerId = null;
   let lastPresetId = null;
   let hasSyncedOnce = false;
+  let retryTimer = null;
+
+  const clearRetryTimer = () => {
+    if (retryTimer) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+  };
+
+  const scheduleRetry = (failureReason, options) => {
+    clearRetryTimer();
+    const { attempt, delayMs } = advanceRetryState(retryState);
+    setRegistryPhase("retrying", "Registry unavailable", {
+      retryAttempt: attempt,
+      retryDelayMs: delayMs,
+    });
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      void sync(failureReason, options);
+    }, delayMs);
+  };
 
   let syncPromise = null;
   async function sync(failureReason = "accounts", options = {}) {
     if (syncPromise) return syncPromise;
+    clearRetryTimer();
+    const previousPhase = registryStore.get().phase;
     syncPromise = (async () => {
       try {
         const url = await prefs.get("registryUrl");
-        if (!url) return;
-
-        let accounts = [];
-        try {
-          accounts = await discoverAccounts(url, auth, options);
-        } catch (err) {
-          console.warn("Failed to discover accounts", err);
+        if (!url) {
+          resetRetryState(retryState);
+          await dismissRegistryUnavailableToast();
+          setRegistryPhase("idle", "", { retryAttempt: 0, retryDelayMs: 0 });
+          return;
         }
+
+        setRegistryPhase("loading", "", {
+          retryAttempt: retryState.attempt,
+          retryDelayMs: 0,
+        });
+
+        const accounts = await discoverAccounts(url, auth, options);
         await prefs.setOptions("accountId", accounts);
 
         const accountId = (await prefs.get("accountId")) || null;
 
-        // Discover APIs natively handle null accountId safely
-        let players = [],
-          presets = [];
-        try {
-          const results = await Promise.allSettled([
-            discoverPlayers(accountId, prefs, auth, options),
-            discoverPresets(accountId, prefs, auth, options),
-          ]);
-          players = results[0].status === "fulfilled" ? results[0].value : [];
-          presets = results[1].status === "fulfilled" ? results[1].value : [];
-        } catch (err) {
-          console.warn("Error resolving players or presets", err);
-        }
+        const [players, presets] = await Promise.all([
+          discoverPlayers(accountId, prefs, auth, options),
+          discoverPresets(accountId, prefs, auth, options),
+        ]);
 
         await prefs.setOptions("playerId", players);
         await prefs.setOptions("presetId", presets);
@@ -88,6 +126,14 @@ export function createSettingsActions({
             );
             await onPlayerSelected(player || null);
             lastPlayerId = player ? resolvedPlayerId : null;
+          } else if (previousPhase !== "ready") {
+            const player = await discoverPlayer(
+              resolvedPlayerId,
+              prefs,
+              auth,
+              options,
+            );
+            await onPlayerSelected(player || null, { reconnectOnly: true });
           }
         } else if (lastPlayerId !== null || !hasSyncedOnce) {
           await onPlayerSelected(null);
@@ -99,13 +145,20 @@ export function createSettingsActions({
           await onPresetSelected(presetId || null);
           lastPresetId = presetId;
         }
+        clearRetryTimer();
+        resetRetryState(retryState);
+        setRegistryPhase("ready", "", { retryAttempt: 0, retryDelayMs: 0 });
+        await dismissRegistryUnavailableToast();
         hasSyncedOnce = true;
       } catch (error) {
         if (error.name !== "AbortError") {
-          toastRegistryFailure(failureReason, error, options);
+          if (retryState.attempt === 0) {
+            toastRegistryUnavailable(error);
+          }
+          scheduleRetry(failureReason, options);
         }
       } finally {
-        if (!hasSyncedOnce) {
+        if (!hasSyncedOnce && registryStore.get().phase === "idle") {
           await onPlayerSelected(null);
           await onPresetSelected(null);
           hasSyncedOnce = true;
@@ -119,13 +172,12 @@ export function createSettingsActions({
 
   return {
     async initialize() {
+      setRegistryPhase("loading", "", { retryAttempt: 0, retryDelayMs: 0 });
       await prefs.init();
       preferencesStore.set({ definitions: prefs.getSnapshot() });
 
       const isOauthCallback = await auth.init();
-      if (!auth.signedIn) {
-        await sync();
-      }
+      await sync();
       return isOauthCallback;
     },
 
@@ -141,7 +193,7 @@ export function createSettingsActions({
           (r) => r.status === "invalid",
         );
         const label = prefs.getSnapshot()[invalid.key]?.label || invalid.key;
-        toastDanger(`⚠️ Failed saving settings. Invalid ${label}.`);
+        toastDanger(`Failed saving settings. Invalid ${label}.`);
         return { status, results };
       }
 

--- a/remote-control/src/js/notifications.js
+++ b/remote-control/src/js/notifications.js
@@ -26,6 +26,7 @@ function showToast(summary, options = {}) {
     format: options.format || "default",
     severity: options.severity || "warning",
     persistent: options.persistent ?? true,
+    dismissible: options.dismissible ?? true,
   }));
 }
 
@@ -46,16 +47,14 @@ export function toastWarning(summary, error = null) {
 }
 
 function registrySummary(summary, { fromSettingsSave = false } = {}) {
-  return fromSettingsSave
-    ? `Saved settings. ${summary.replace(/^⚠️\s*/, "").trim()}`
-    : summary;
+  return fromSettingsSave ? `Saved settings. ${summary}` : summary;
 }
 
 const REGISTRY_FAILURE_MESSAGES = {
-  accounts: "⚠️ Failed refreshing accounts.",
-  auth_accounts: "⚠️ Failed refreshing accounts after auth change.",
-  account_choices: "⚠️ Failed refreshing account players/presets.",
-  player: "⚠️ Failed refreshing player info.",
+  accounts: "Failed refreshing accounts.",
+  auth_accounts: "Failed refreshing accounts after auth change.",
+  account_choices: "Failed refreshing account players/presets.",
+  player: "Failed refreshing player info.",
 };
 
 function registryFailureMessage(reason = "accounts") {
@@ -71,6 +70,26 @@ export function toastRegistryFailure(reason, error, options = {}) {
     persistent: true,
     severity: "warning",
   });
+}
+
+export function toastRegistryUnavailable(error = null) {
+  showToast("Registry unavailable.", {
+    error,
+    format: "registry-status",
+    persistent: true,
+    severity: "warning",
+  });
+}
+
+export async function dismissRegistryUnavailableToast() {
+  if (toastStore.get().format !== "registry-status") {
+    return;
+  }
+
+  const toast = document.querySelector("#global-toast");
+  if (toast) {
+    await toast.dismiss();
+  }
 }
 
 export function toastSuccess(summary) {
@@ -101,13 +120,23 @@ async function presentToast(notification) {
   const message = detailText
     ? `${notification.summary} ${detailText}`.trim()
     : notification.summary;
+  const icon =
+    notification.format === "registry-status"
+      ? "cloud-offline-outline"
+      : notification.severity === "success"
+        ? "checkmark-circle-outline"
+        : notification.severity === "danger"
+          ? "alert-circle-outline"
+          : "warning-outline";
 
   toast.message = message;
+  toast.icon = icon;
   toast.duration = notification.persistent ? 0 : config.duration;
   toast.color = config.color;
-  toast.buttons = notification.persistent
-    ? [{ text: "Dismiss", role: "cancel" }]
-    : [];
+  toast.buttons =
+    notification.persistent && notification.dismissible !== false
+      ? [{ text: "Dismiss", role: "cancel" }]
+      : [];
   toast.position = config.position;
   await toast.present();
 }

--- a/remote-control/src/js/services/radio-control.js
+++ b/remote-control/src/js/services/radio-control.js
@@ -17,6 +17,19 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Capacitor } from "@capacitor/core";
+import {
+  advanceRetryState,
+  createRetryState,
+  resetRetryState,
+} from "../utils/retry.js";
+
+const CONTROL_CONNECT_TIMEOUT_MS = 4000;
+const CONTROL_RETRY_OPTIONS = {
+  initialDelayMs: 500,
+  factor: 1.5,
+  jitterMs: 500,
+  maxDelayMs: 8000,
+};
 
 function resolveSwitchboardPath(basePath, targetPath) {
   const normalizedBasePath = basePath.replace(/\/$/, "");
@@ -47,12 +60,32 @@ function resolvePlayerSwitchboardUrl(url) {
   }
 }
 
+function resolvePlayerStationsUrl(url) {
+  if (!(url && !Capacitor.isNativePlatform())) {
+    return url;
+  }
+
+  try {
+    const target = new URL(url);
+    const local = new URL(window.location.origin);
+    const apiPath = local.pathname.replace(/\/$/, "");
+
+    local.pathname = target.pathname.replace(/^\/api/, apiPath || "/api");
+    local.search = target.search;
+    local.hash = target.hash;
+    return local.toString();
+  } catch (error) {
+    console.warn("Invalid stations URL received from player.", error);
+    return url;
+  }
+}
+
 export class RadioControl extends EventTarget {
   constructor() {
     super();
     this.ws = null;
     this.reconnectTimer = null;
-    this.reconnectDelay = 1000;
+    this.retryState = createRetryState(CONTROL_RETRY_OPTIONS);
     this._lastUrl = null;
     this._lastToken = null;
   }
@@ -134,11 +167,11 @@ export class RadioControl extends EventTarget {
       if (ws.readyState !== WebSocket.OPEN) {
         ws.close();
       }
-    }, 10000);
+    }, CONTROL_CONNECT_TIMEOUT_MS);
 
     ws.onopen = () => {
       clearTimeout(this.connectTimer);
-      this.reconnectDelay = 1000;
+      resetRetryState(this.retryState);
       if (this.reconnectTimer) {
         clearTimeout(this.reconnectTimer);
       }
@@ -169,7 +202,9 @@ export class RadioControl extends EventTarget {
             break;
           case "stations_url":
             this.dispatchEvent(
-              new CustomEvent("stationsurl", { detail: data }),
+              new CustomEvent("stationsurl", {
+                detail: resolvePlayerStationsUrl(data),
+              }),
             );
             break;
         }
@@ -190,16 +225,12 @@ export class RadioControl extends EventTarget {
     // Only schedule a reconnect if we still have an active URL and haven't explicitly disconnected
     if (!this._lastUrl) return;
 
+    const { delayMs } = advanceRetryState(this.retryState);
+
     this.reconnectTimer = setTimeout(() => {
       if (this._lastUrl) {
         this._connectWebSocket(this._lastUrl, this._lastToken);
-        // Exponential backoff with a bit of random jitter (up to 1s) to avoid server stampedes
-        const jitter = Math.random() * 1000;
-        this.reconnectDelay = Math.min(
-          this.reconnectDelay * 1.5 + jitter,
-          30000,
-        );
       }
-    }, this.reconnectDelay);
+    }, delayMs);
   }
 }

--- a/remote-control/src/js/services/registry-discovery.js
+++ b/remote-control/src/js/services/registry-discovery.js
@@ -18,8 +18,31 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import { RegistryRequestError } from "../utils/errors.js";
 
+const REGISTRY_REQUEST_TIMEOUT_MS = 10000;
+
 function resolveRegistryBaseUrl(registryUrl) {
   return new URL(registryUrl, window.location.origin).toString();
+}
+
+function inferPlayerStationsUrl(registryUrl, accountId) {
+  return new URL(
+    `presets/${accountId}`,
+    resolveRegistryBaseUrl(registryUrl),
+  ).toString();
+}
+
+function inferPlayerSwitchboardUrl(registryUrl, accountId, playerId) {
+  const baseUrl = new URL(resolveRegistryBaseUrl(registryUrl));
+  const scheme = baseUrl.protocol === "https:" ? "wss:" : "ws:";
+  const apiPath = baseUrl.pathname.replace(/\/$/, "");
+  const switchboardPath = apiPath.endsWith("/api")
+    ? `${apiPath.slice(0, -4)}/switchboard/${accountId}/${playerId}`
+    : `${apiPath}/switchboard/${accountId}/${playerId}`;
+
+  return new URL(
+    `${scheme}//${baseUrl.host}${switchboardPath}`,
+    window.location.origin,
+  ).toString();
 }
 
 function buildRequestOptions(auth, signal) {
@@ -30,6 +53,38 @@ function buildRequestOptions(auth, signal) {
     ...(headers ? { headers } : {}),
     ...(signal ? { signal } : {}),
   };
+}
+
+async function fetchWithTimeout(url, options) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort(new Error("Request timed out."));
+  }, REGISTRY_REQUEST_TIMEOUT_MS);
+  const relayAbort = () => controller.abort(options.signal?.reason);
+
+  if (options.signal) {
+    if (options.signal.aborted) {
+      controller.abort(options.signal.reason);
+    } else {
+      options.signal.addEventListener("abort", relayAbort, { once: true });
+    }
+  }
+
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } catch (error) {
+    if (
+      controller.signal.aborted &&
+      controller.signal.reason instanceof Error &&
+      controller.signal.reason.message === "Request timed out."
+    ) {
+      throw controller.signal.reason;
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+    options.signal?.removeEventListener("abort", relayAbort);
+  }
 }
 
 async function fetchAllPages(
@@ -44,7 +99,7 @@ async function fetchAllPages(
   const options = buildRequestOptions(auth, signal);
 
   while (url) {
-    const resp = await fetch(url, options);
+    const resp = await fetchWithTimeout(url, options);
     if (!resp.ok) {
       throw new RegistryRequestError({ url, status: resp.status });
     }
@@ -163,13 +218,21 @@ export async function discoverPlayer(
       `accounts/${accountId}/players/${playerId}`,
       resolveRegistryBaseUrl(registryUrl),
     ).toString();
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       url,
       buildRequestOptions(auth, options.signal),
     );
     if (!response.ok) {
       throw new RegistryRequestError({ url, status: response.status });
     }
-    return await response.json();
+    const player = await response.json();
+    return {
+      ...player,
+      stations_url:
+        player.stations_url || inferPlayerStationsUrl(registryUrl, accountId),
+      switchboard_url:
+        player.switchboard_url ||
+        inferPlayerSwitchboardUrl(registryUrl, accountId, playerId),
+    };
   });
 }

--- a/remote-control/src/js/store.js
+++ b/remote-control/src/js/store.js
@@ -43,6 +43,13 @@ export const settingsUiStore = atom({
   saveState: "idle",
 });
 
+export const registryStore = atom({
+  phase: "idle",
+  errorText: "",
+  retryAttempt: 0,
+  retryDelayMs: 0,
+});
+
 export const controlStore = atom({
   player: EMPTY_PLAYER,
   stationsData: null,
@@ -83,6 +90,7 @@ if (import.meta.env.DEV && import.meta.env.MODE !== "test") {
       authStore,
       preferencesStore,
       settingsUiStore,
+      registryStore,
       controlStore,
       listenStore,
       toastStore,

--- a/remote-control/src/js/utils/retry.js
+++ b/remote-control/src/js/utils/retry.js
@@ -1,0 +1,58 @@
+/*
+This file is part of the radio-pad project.
+https://github.com/briceburg/radio-pad
+
+Copyright (c) 2025 Brice Burgess <https://github.com/briceburg>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+const DEFAULT_RETRY_OPTIONS = {
+  initialDelayMs: 1000,
+  factor: 1.5,
+  jitterMs: 1000,
+  maxDelayMs: 30000,
+};
+
+export function createRetryState(options = {}) {
+  const config = {
+    ...DEFAULT_RETRY_OPTIONS,
+    ...options,
+  };
+
+  return {
+    ...config,
+    attempt: 0,
+    nextDelayMs: config.initialDelayMs,
+  };
+}
+
+export function resetRetryState(retryState) {
+  retryState.attempt = 0;
+  retryState.nextDelayMs = retryState.initialDelayMs;
+}
+
+export function advanceRetryState(retryState) {
+  const delayMs = retryState.nextDelayMs;
+  const jitter = retryState.jitterMs ? Math.random() * retryState.jitterMs : 0;
+
+  retryState.attempt += 1;
+  retryState.nextDelayMs = Math.min(
+    retryState.nextDelayMs * retryState.factor + jitter,
+    retryState.maxDelayMs,
+  );
+
+  return {
+    attempt: retryState.attempt,
+    delayMs,
+  };
+}

--- a/remote-control/tests/actions/settings-actions.test.js
+++ b/remote-control/tests/actions/settings-actions.test.js
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/js/services/registry-discovery.js", () => ({
+  discoverAccounts: vi.fn(),
+  discoverPlayer: vi.fn(),
+  discoverPlayers: vi.fn(),
+  discoverPresets: vi.fn(),
+}));
+
+vi.mock("../../src/js/notifications.js", () => ({
+  dismissRegistryUnavailableToast: vi.fn(),
+  toastDanger: vi.fn(),
+  toastRegistryUnavailable: vi.fn(),
+}));
+
+import { createSettingsActions } from "../../src/js/actions/settings-actions.js";
+import { preferencesStore, registryStore } from "../../src/js/store.js";
+import {
+  discoverAccounts,
+  discoverPlayer,
+  discoverPlayers,
+  discoverPresets,
+} from "../../src/js/services/registry-discovery.js";
+
+describe("settings-actions", () => {
+  beforeEach(() => {
+    preferencesStore.set({ definitions: {} });
+    registryStore.set({
+      phase: "idle",
+      errorText: "",
+      retryAttempt: 0,
+      retryDelayMs: 0,
+    });
+    vi.clearAllMocks();
+  });
+
+  it("reconnects the selected player after registry recovery without resetting control state", async () => {
+    const player = {
+      id: "living-room",
+      name: "Living Room",
+      stations_url: "http://localhost:3000/api/presets/briceburg",
+      switchboard_url: "ws://localhost:3000/switchboard/briceburg/living-room",
+    };
+    const prefs = {
+      get: vi.fn(async (key) => {
+        if (key === "registryUrl") return "/api/";
+        if (key === "accountId") return "briceburg";
+        if (key === "playerId") return "living-room";
+        if (key === "presetId")
+          return "http://localhost:3000/api/presets/briceburg";
+        return null;
+      }),
+      setOptions: vi.fn(async () => {}),
+      getSnapshot: vi.fn(() => ({})),
+      init: vi.fn(async () => {}),
+    };
+    const auth = {
+      signedIn: true,
+      init: vi.fn(async () => false),
+      addEventListener: vi.fn(),
+      getState: vi.fn(() => ({})),
+    };
+
+    discoverAccounts.mockResolvedValue([
+      { value: "briceburg", label: "Briceburg" },
+    ]);
+    discoverPlayers.mockResolvedValue([
+      { value: "living-room", label: "Living Room" },
+    ]);
+    discoverPresets.mockResolvedValue([
+      {
+        value: "http://localhost:3000/api/presets/briceburg",
+        label: "Casa Briceburg",
+      },
+    ]);
+    discoverPlayer.mockResolvedValue(player);
+
+    const onPlayerSelected = vi.fn(async () => {});
+    const onPresetSelected = vi.fn(async () => {});
+    const actions = createSettingsActions({
+      prefs,
+      auth,
+      onPlayerSelected,
+      onPresetSelected,
+    });
+
+    await actions.sync();
+    expect(onPlayerSelected).toHaveBeenLastCalledWith(player);
+
+    registryStore.set({
+      phase: "retrying",
+      errorText: "Registry unavailable",
+      retryAttempt: 2,
+      retryDelayMs: 1000,
+    });
+
+    await actions.sync();
+
+    expect(onPlayerSelected).toHaveBeenLastCalledWith(player, {
+      reconnectOnly: true,
+    });
+  });
+
+  it("sets phase to ready after successful sync", async () => {
+    const prefs = {
+      get: vi.fn(async (key) => {
+        if (key === "registryUrl") return "/api/";
+        return null;
+      }),
+      setOptions: vi.fn(async () => {}),
+      getSnapshot: vi.fn(() => ({})),
+    };
+    const auth = { signedIn: false };
+
+    discoverAccounts.mockResolvedValue([]);
+    discoverPlayers.mockResolvedValue([]);
+    discoverPresets.mockResolvedValue([]);
+
+    const actions = createSettingsActions({
+      prefs,
+      auth,
+      onPlayerSelected: vi.fn(async () => {}),
+      onPresetSelected: vi.fn(async () => {}),
+    });
+
+    await actions.sync();
+    expect(registryStore.get().phase).toBe("ready");
+  });
+
+  it("schedules retry on sync failure", async () => {
+    vi.useFakeTimers();
+
+    const prefs = {
+      get: vi.fn(async () => "/api/"),
+      setOptions: vi.fn(async () => {}),
+      getSnapshot: vi.fn(() => ({})),
+    };
+    const auth = { signedIn: false };
+
+    discoverAccounts.mockRejectedValue(new Error("Network error"));
+
+    const actions = createSettingsActions({
+      prefs,
+      auth,
+      onPlayerSelected: vi.fn(async () => {}),
+      onPresetSelected: vi.fn(async () => {}),
+    });
+
+    await actions.sync();
+    expect(registryStore.get().phase).toBe("retrying");
+    expect(registryStore.get().retryAttempt).toBe(1);
+
+    vi.useRealTimers();
+  });
+});

--- a/remote-control/tests/services/radio-control.test.js
+++ b/remote-control/tests/services/radio-control.test.js
@@ -10,22 +10,27 @@ vi.mock("@capacitor/core", () => ({
 
 describe("RadioControl", () => {
   let mockWebSocketInstance;
-  
+
   beforeEach(() => {
     vi.useFakeTimers();
     mockWebSocketInstance = {
-      readyState: WebSocket.CONNECTING,
       close: vi.fn(),
       send: vi.fn(),
     };
-    global.WebSocket = vi.fn(function (url) {
+    const MockWebSocket = vi.fn(function (url) {
       this.url = url;
       Object.assign(this, mockWebSocketInstance);
       return this;
     });
+    MockWebSocket.CONNECTING = 0;
+    MockWebSocket.OPEN = 1;
+    MockWebSocket.CLOSING = 2;
+    MockWebSocket.CLOSED = 3;
+    mockWebSocketInstance.readyState = MockWebSocket.CONNECTING;
+    global.WebSocket = MockWebSocket;
     Capacitor.isNativePlatform.mockReturnValue(false);
   });
-  
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -33,10 +38,12 @@ describe("RadioControl", () => {
   it("resolves switchboard URL override correctly in browser mode", async () => {
     vi.stubEnv("VITE_SWITCHBOARD_URL", "ws://localhost:8080");
     const rc = new RadioControl();
-    
+
     rc.connect("ws://remote-server:9000/player/foo?token=123");
-    
-    expect(global.WebSocket).toHaveBeenCalledWith("ws://localhost:8080/player/foo?token=123");
+
+    expect(global.WebSocket).toHaveBeenCalledWith(
+      "ws://localhost:8080/player/foo?token=123",
+    );
   });
 
   it("resolves same-origin switchboard overrides correctly in browser mode", async () => {
@@ -54,35 +61,87 @@ describe("RadioControl", () => {
     vi.stubEnv("VITE_SWITCHBOARD_URL", "ws://localhost:8080");
     Capacitor.isNativePlatform.mockReturnValue(true);
     const rc = new RadioControl();
-    
+
     rc.connect("ws://remote-server:9000/player/foo?token=123");
-    
-    expect(global.WebSocket).toHaveBeenCalledWith("ws://remote-server:9000/player/foo?token=123");
+
+    expect(global.WebSocket).toHaveBeenCalledWith(
+      "ws://remote-server:9000/player/foo?token=123",
+    );
   });
-  
+
   it("sending station request works when connected", async () => {
     const rc = new RadioControl();
     rc.connect("ws://example.com/");
-    
+
     // simulate open
-    mockWebSocketInstance.readyState = WebSocket.OPEN;
-    
+    rc.ws.readyState = WebSocket.OPEN;
+
     rc.sendStationRequest("WXXI");
-    
-    expect(mockWebSocketInstance.send).toHaveBeenCalledWith(JSON.stringify({
-      event: "station_request",
-      data: "WXXI"
-    }));
+
+    expect(mockWebSocketInstance.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        event: "station_request",
+        data: "WXXI",
+      }),
+    );
+  });
+
+  it("rewrites player stations_url messages through the local api proxy", async () => {
+    const rc = new RadioControl();
+    const stationsSpy = vi.fn();
+    rc.addEventListener("stationsurl", stationsSpy);
+
+    rc.connect("ws://example.com/");
+
+    rc.ws.onmessage({
+      data: JSON.stringify({
+        event: "stations_url",
+        data: "http://registry:1980/api/presets/briceburg",
+      }),
+    });
+
+    expect(stationsSpy).toHaveBeenCalledTimes(1);
+    expect(stationsSpy.mock.calls[0][0].detail).toBe(
+      "http://localhost:3000/api/presets/briceburg",
+    );
   });
 
   it("sends error event if sending request while disconnected", async () => {
     const rc = new RadioControl();
     const errorSpy = vi.fn();
     rc.addEventListener("error", errorSpy);
-    
+
     // we never call connect() or don't set readyState
     rc.sendStationRequest("WXXI");
-    
+
     expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("retries control websocket reconnects promptly after disconnect", async () => {
+    const rc = new RadioControl();
+
+    rc.connect("ws://example.com/");
+    expect(global.WebSocket).toHaveBeenCalledTimes(1);
+
+    rc.ws.readyState = WebSocket.CLOSED;
+    rc.ws.onclose();
+
+    await vi.advanceTimersByTimeAsync(499);
+    expect(global.WebSocket).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(global.WebSocket).toHaveBeenCalledTimes(2);
+  });
+
+  it("closes stalled websocket connection attempts after the control timeout", async () => {
+    const rc = new RadioControl();
+
+    rc.connect("ws://example.com/");
+
+    await vi.advanceTimersByTimeAsync(3999);
+    expect(mockWebSocketInstance.close).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(mockWebSocketInstance.close).toHaveBeenCalledTimes(1);
   });
 });

--- a/remote-control/tests/services/registry-discovery.test.js
+++ b/remote-control/tests/services/registry-discovery.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { discoverAccounts } from "../../src/js/services/registry-discovery.js";
+import {
+  discoverAccounts,
+  discoverPlayer,
+} from "../../src/js/services/registry-discovery.js";
 
 describe("Registry Discovery", () => {
   beforeEach(() => {
@@ -12,8 +15,8 @@ describe("Registry Discovery", () => {
       ok: true,
       json: async () => ({
         items: [{ id: "acct1", name: "Account One" }],
-        links: { next: "/v1/accounts?page=2" }
-      })
+        links: { next: "/v1/accounts?page=2" },
+      }),
     });
 
     // Mock the second fetch response (no next link)
@@ -21,17 +24,17 @@ describe("Registry Discovery", () => {
       ok: true,
       json: async () => ({
         items: [{ id: "acct2", name: "Account Two" }],
-        links: {}
-      })
+        links: {},
+      }),
     });
 
     const accounts = await discoverAccounts("http://mock-registry");
-    
+
     expect(global.fetch).toHaveBeenCalledTimes(2);
     // Should extract map { value, label } output correctly
     expect(accounts).toEqual([
       { value: "acct1", label: "Account One" },
-      { value: "acct2", label: "Account Two" }
+      { value: "acct2", label: "Account Two" },
     ]);
   });
 
@@ -40,15 +43,46 @@ describe("Registry Discovery", () => {
       ok: true,
       json: async () => ({
         items: [{ id: "acct1", name: "Account One" }],
-        links: {}
-      })
+        links: {},
+      }),
     });
 
     await discoverAccounts("/api/");
 
     expect(global.fetch).toHaveBeenCalledWith(
       "http://localhost:3000/api/accounts/",
-      {},
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      }),
     );
+  });
+
+  it("discoverPlayer infers missing player urls from the registry base", async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        id: "living-room",
+        name: "Living Room",
+        account_id: "briceburg",
+        stations_url: null,
+        switchboard_url: null,
+      }),
+    });
+
+    const prefs = {
+      get: vi.fn(async (key) => {
+        if (key === "accountId") return "briceburg";
+        if (key === "registryUrl") return "/api/";
+        return null;
+      }),
+    };
+
+    const player = await discoverPlayer("living-room", prefs);
+
+    expect(player).toMatchObject({
+      id: "living-room",
+      stations_url: "http://localhost:3000/api/presets/briceburg",
+      switchboard_url: "ws://localhost:3000/switchboard/briceburg/living-room",
+    });
   });
 });

--- a/remote-control/tests/utils/retry.test.js
+++ b/remote-control/tests/utils/retry.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  advanceRetryState,
+  createRetryState,
+  resetRetryState,
+} from "../../src/js/utils/retry.js";
+
+describe("retry helpers", () => {
+  it("advances attempts and delay deterministically without jitter", () => {
+    const state = createRetryState({
+      initialDelayMs: 1000,
+      factor: 2,
+      jitterMs: 0,
+      maxDelayMs: 5000,
+    });
+
+    expect(advanceRetryState(state)).toEqual({ attempt: 1, delayMs: 1000 });
+    expect(advanceRetryState(state)).toEqual({ attempt: 2, delayMs: 2000 });
+    expect(advanceRetryState(state)).toEqual({ attempt: 3, delayMs: 4000 });
+    expect(advanceRetryState(state)).toEqual({ attempt: 4, delayMs: 5000 });
+  });
+
+  it("resets back to the initial delay and zero attempts", () => {
+    const state = createRetryState({
+      initialDelayMs: 750,
+      factor: 2,
+      jitterMs: 0,
+      maxDelayMs: 5000,
+    });
+
+    advanceRetryState(state);
+    advanceRetryState(state);
+    resetRetryState(state);
+
+    expect(state.attempt).toBe(0);
+    expect(state.nextDelayMs).toBe(750);
+  });
+
+  it("caps delay at maxDelayMs", () => {
+    const state = createRetryState({
+      initialDelayMs: 1000,
+      factor: 10,
+      jitterMs: 0,
+      maxDelayMs: 5000,
+    });
+
+    advanceRetryState(state);
+    const { delayMs } = advanceRetryState(state);
+    expect(delayMs).toBe(5000);
+  });
+});


### PR DESCRIPTION
## PR 5: Remote-control registry sync resilience

Part of the [macropad status unification](https://github.com/briceburg/radio-pad/tree/feat/macropad-status-unification) decomposition. **Independent** — no dependencies on other PRs.

### Problem

When the registry is unreachable (network issue, service down), the remote-control silently swallows errors and shows no feedback. Users see a blank player tab with no indication of what's wrong or that recovery is in progress.

### Changes

**New: `src/js/utils/retry.js`** — Reusable exponential backoff state machine
- `createRetryState(options)`: configurable initial delay, factor, jitter, max
- `advanceRetryState(state)`: returns `{attempt, delayMs}`, advances exponentially
- `resetRetryState(state)`: reset on success

**`src/js/services/registry-discovery.js`** — Error propagation + timeout
- Add `fetchWithTimeout()` (10s) with AbortSignal relay
- Add `inferPlayerStationsUrl()` / `inferPlayerSwitchboardUrl()` — derive missing URLs from registry base
- `discoverPlayer()` enriches response with inferred URLs when API omits them
- Replace bare `fetch()` with `fetchWithTimeout()` in pagination

**`src/js/actions/settings-actions.js`** — Retry orchestration
- Track registry sync phase: `idle → loading → ready | retrying`
- Replace error-swallowing with `scheduleRetry()` (exponential backoff)
- On recovery: reconnect player with `{ reconnectOnly: true }`
- Always sync on initialize (previously skipped when signed in)
- Show toast on first failure, dismiss on recovery

**`src/js/store.js`** — New `registryStore` atom
- Tracks `{ phase, errorText, retryAttempt, retryDelayMs }`

**`src/js/notifications.js`** — Registry-aware toasts
- Add `toastRegistryUnavailable()` / `dismissRegistryUnavailableToast()`
- Add icon support (cloud-offline, checkmark, alert, warning)
- Add `dismissible` option (non-dismissible for persistent status toasts)
- Remove emoji prefixes from all messages

**`src/js/services/radio-control.js`** — Shared retry for WebSocket
- Replace inline backoff with `createRetryState()` (500ms initial, 1.5x, 8s max)
- Reduce connect timeout from 10s to 4s
- Add `resolvePlayerStationsUrl()` for same-origin proxy rewriting

**`src/js/actions/auth-actions.js`** — Skip redundant initial sync
- Guard against double-sync when auth fires initial statechange
- Remove emoji prefixes

### Design decisions

- **Error propagation over swallowing**: `Promise.all` replaces `Promise.allSettled` — if accounts fail, everything fails and retries together
- **Retry constants**: Registry (1s initial, 1.5x, 30s max) vs WebSocket (500ms, 1.5x, 8s max) — WebSocket reconnects faster since it's a sustained connection
- **`reconnectOnly`**: After registry recovery, re-select the same player without resetting cached stations/state. Consumed by control-actions in PR 6
- **Toast lifecycle**: First failure shows persistent toast; retries update store silently; success dismisses toast

### Tests (27 pass, 9 new)

- `retry.test.js`: deterministic backoff, reset, max cap
- `registry-discovery.test.js`: URL inference for missing player URLs
- `settings-actions.test.js`: phase transitions, recovery reconnect, retry scheduling
- `radio-control.test.js`: reconnect timing, connect timeout