### PR TITLE
feat(remote-control): degraded UI — amber skeletons & registry status

### DIFF
--- a/remote-control/src/css/style.css
+++ b/remote-control/src/css/style.css
@@ -17,3 +17,8 @@ ion-row.station-placeholder ion-skeleton-text {
   height: 2em;
   width: 100%;
 }
+
+ion-row.station-placeholder-warning ion-skeleton-text {
+  --background: var(--ion-color-warning, #ffc409);
+  --background-rgb: var(--ion-color-warning-rgb, 255, 196, 9);
+}

--- a/remote-control/src/js/actions/control-actions.js
+++ b/remote-control/src/js/actions/control-actions.js
@@ -16,66 +16,106 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { authStore, controlStore, listenStore, patchStore } from "../store.js";
+import {
+  authStore,
+  controlStore,
+  listenStore,
+  patchStore,
+  preferencesStore,
+} from "../store.js";
 import { toastWarning } from "../notifications.js";
 
 export function createControlActions({ control, listen }) {
   const getTabStore = (tabName) =>
     tabName === "listen" ? listenStore : controlStore;
   const updateTab = (tabName, state) => patchStore(getTabStore(tabName), state);
+  const getOptionLabel = (key, value) => {
+    const options = preferencesStore.get().definitions?.[key]?.options || [];
+    return (
+      options.find((option) => option.value === value)?.label || value || null
+    );
+  };
+  const requestControllers = { control: null, listen: null };
 
-  // Track out-of-order fetch responses by storing current URL
-  const currentRequests = { control: null, listen: null };
+  const abortStationLoad = (tabName) => {
+    requestControllers[tabName]?.abort();
+    requestControllers[tabName] = null;
+  };
 
-  async function loadStations(url, tabName = "control") {
+  async function loadStations(url, tabName = "control", titleName = null) {
     if (!url) {
+      abortStationLoad(tabName);
       updateTab(tabName, {
         stationsData: null,
         currentStation: null,
         loading: false,
+        ...(tabName === "listen" ? { titleName } : {}),
       });
       return null;
     }
 
-    updateTab(tabName, { loading: true });
-    currentRequests[tabName] = url;
+    updateTab(tabName, {
+      loading: true,
+      ...(tabName === "listen" ? { titleName } : {}),
+    });
+    abortStationLoad(tabName);
+    const controller = new AbortController();
+    requestControllers[tabName] = controller;
 
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, { signal: controller.signal });
       if (!response.ok) throw new Error(`Fetch failed (${response.status})`);
 
       const stationsData = await response.json();
-
-      // Prevent stale updates if another fetch started
-      if (currentRequests[tabName] !== url) return null;
+      if (requestControllers[tabName] !== controller) return null;
 
       if (tabName === "listen") listen.setStations(stationsData);
 
-      updateTab(tabName, { stationsData, loading: false });
+      updateTab(tabName, {
+        stationsData,
+        loading: false,
+        ...(tabName === "control"
+          ? { connectionState: "connected" }
+          : { titleName: stationsData?.name || titleName }),
+      });
+      requestControllers[tabName] = null;
       return stationsData;
     } catch (error) {
-      if (currentRequests[tabName] !== url) return null;
+      if (
+        error.name === "AbortError" ||
+        requestControllers[tabName] !== controller
+      ) {
+        return null;
+      }
 
+      requestControllers[tabName] = null;
       updateTab(tabName, { loading: false });
-      toastWarning("⚠️ Failed loading stations.", error);
+      toastWarning("Failed loading stations.", error);
       return null;
     }
   }
 
   control.addEventListener("connect", () =>
     updateTab("control", {
-      statusText: `✅ Connected to ${controlStore.get().player.name}`,
+      statusText: `Connected to ${controlStore.get().player.name}`,
+      connectionState: "connected",
     }),
   );
   control.addEventListener("connecting", () =>
-    updateTab("control", { statusText: "🔄 Connecting..." }),
+    updateTab("control", {
+      statusText: "Connecting to switchboard...",
+      connectionState: "connecting",
+    }),
   );
   control.addEventListener("disconnect", () =>
-    updateTab("control", { statusText: "🔌 Disconnected. Reconnecting..." }),
+    updateTab("control", {
+      statusText: controlStore.get().player?.id
+        ? "Switchboard unavailable. Reconnecting..."
+        : "Disconnected.",
+      connectionState: "disconnected",
+    }),
   );
-  control.addEventListener("error", (event) =>
-    toastWarning(`⚠️ ${event.detail}`),
-  );
+  control.addEventListener("error", (event) => toastWarning(event.detail));
   control.addEventListener("stationplaying", (event) =>
     updateTab("control", { currentStation: event.detail }),
   );
@@ -101,31 +141,41 @@ export function createControlActions({ control, listen }) {
   });
 
   return {
-    async selectPlayer(player) {
-      updateTab("control", {
-        player,
-        stationsData: null,
-        currentStation: null,
-        statusText: "",
-        loading: player ? true : false,
-      });
-      if (!player) {
+    async selectPlayer(player, options = {}) {
+      const { reconnectOnly = false } = options;
+      if (reconnectOnly) {
+        updateTab("control", { connectionState: "connecting" });
+      } else {
+        abortStationLoad("control");
+        updateTab("control", {
+          player,
+          stationsData: null,
+          currentStation: null,
+          statusText: "",
+          loading: player ? true : false,
+          connectionState: player ? "connecting" : "idle",
+        });
+      }
+      if (!player?.switchboard_url) {
         control.disconnect();
         return;
       }
       const token = authStore.get()?.registryBearerToken || null;
       await control.connect(player.switchboard_url, token);
+      if (!reconnectOnly) {
+        await loadStations(player.stations_url, "control");
+      }
     },
 
     async selectPreset(presetId) {
-      return loadStations(presetId, "listen");
+      const label = getOptionLabel("preset", presetId);
+      return loadStations(presetId, "listen", label);
     },
 
     async clickStation(tabName, station) {
       if (tabName === "listen") {
         const started = await listen.play(station);
-        if (!started)
-          return toastWarning("⚠️ Failed starting station playback.");
+        if (!started) return toastWarning("Failed starting station playback.");
         return updateTab("listen", { currentStation: station });
       }
       control.sendStationRequest(station);

--- a/remote-control/src/js/app.js
+++ b/remote-control/src/js/app.js
@@ -47,7 +47,8 @@ async function bootstrap() {
   const settingsActions = createSettingsActions({
     prefs,
     auth,
-    onPlayerSelected: (player) => controlActions.selectPlayer(player),
+    onPlayerSelected: (player, options) =>
+      controlActions.selectPlayer(player, options),
     onPresetSelected: (presetId) => controlActions.selectPreset(presetId),
   });
   const authActions = createAuthActions({
@@ -88,5 +89,5 @@ async function bootstrap() {
 
 void bootstrap().catch((error) => {
   console.error("Failed bootstrapping remote control app", error);
-  toastDanger("⚠️ Failed starting remote control.", error);
+  toastDanger("Failed starting remote control.", error);
 });

--- a/remote-control/src/js/services/auth.js
+++ b/remote-control/src/js/services/auth.js
@@ -86,7 +86,7 @@ export class RadioPadAuth extends EventTarget {
       this.initError = error;
       this.dispatchEvent(
         new CustomEvent("error", {
-          detail: { summary: "⚠️ Sign-in unavailable.", error },
+          detail: { summary: "Sign-in unavailable.", error },
         }),
       );
       return this.emitAuthState();
@@ -103,7 +103,7 @@ export class RadioPadAuth extends EventTarget {
       } catch (error) {
         this.dispatchEvent(
           new CustomEvent("error", {
-            detail: { summary: "⚠️ Sign-in failed.", error },
+            detail: { summary: "Sign-in failed.", error },
           }),
         );
       }

--- a/remote-control/src/js/store.js
+++ b/remote-control/src/js/store.js
@@ -54,7 +54,8 @@ export const controlStore = atom({
   player: EMPTY_PLAYER,
   stationsData: null,
   currentStation: null,
-  loading: true,
+  loading: false,
+  connectionState: "idle",
   statusText: "",
 });
 
@@ -62,6 +63,7 @@ export const listenStore = atom({
   stationsData: null,
   currentStation: null,
   loading: false,
+  titleName: null,
 });
 
 export const toastStore = atom({

--- a/remote-control/src/js/ui/radio-player-tab.js
+++ b/remote-control/src/js/ui/radio-player-tab.js
@@ -19,15 +19,93 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 import { html } from "lit";
 import { RadioElement } from "./radio-element.js";
 import { StoreController } from "@nanostores/lit";
-import { controlStore, listenStore } from "../store.js";
+import { controlStore, listenStore, registryStore } from "../store.js";
+import {
+  isRegistryPending,
+  getRegistryPendingTitle,
+} from "./registry-status.js";
 
-function renderSkeleton() {
+/**
+ * Derive a display-friendly status text from the registry state.
+ * Returns a short string when registry is pending, empty otherwise.
+ */
+export function getRegistryStatusText(registryState) {
+  if (!isRegistryPending(registryState)) return "";
+  return "Connecting to Registry";
+}
+
+/**
+ * Build the title prefix (left side of colon).
+ * For control: use player name. For listen: use titleName from the store.
+ */
+export function getTitlePrefix(tabName, state) {
+  if (tabName === "listen") return state.titleName || "";
+  return state.player?.name || "";
+}
+
+/**
+ * Build the title suffix (right side of colon).
+ * Shows current station, loading indicator, or registry status.
+ */
+export function getTitleSuffix(tabName, state, registryState) {
+  if (state.currentStation) return state.currentStation;
+  if (state.loading) return "Loading...";
+
+  const hasContent =
+    tabName === "control" ? !!state.player?.id : !!state.stationsData;
+  if (!hasContent && isRegistryPending(registryState)) {
+    return getRegistryStatusText(registryState);
+  }
+  return "...";
+}
+
+/**
+ * Determine whether to render skeleton placeholders.
+ * Skeletons show during initial loading or pending registry discovery.
+ */
+export function shouldRenderSkeleton(tabName, state, registryState) {
+  if (state.loading) return true;
+  const hasContent =
+    tabName === "control" ? !!state.player?.id : !!state.stationsData;
+  return !hasContent && isRegistryPending(registryState);
+}
+
+/**
+ * Determine the visual state of station buttons:
+ *   "normal" — healthy, "warning" — degraded, "loading" — skeleton placeholder
+ */
+export function getStationVisualState(tabName, state, registryState) {
+  if (shouldRenderSkeleton(tabName, state, registryState)) return "loading";
+  if (!state.stationsData) return "normal";
+  if (
+    tabName === "control" &&
+    state.connectionState &&
+    state.connectionState !== "connected"
+  ) {
+    return "warning";
+  }
+  return "normal";
+}
+
+/**
+ * Map visual state to ion-button color, respecting active station override.
+ */
+export function getStationButtonColor(visualState, isActive) {
+  if (isActive) return "success";
+  return visualState === "warning" ? "warning" : "primary";
+}
+
+function renderSkeleton(visualState = "loading") {
   const rows = [1, 2, 3];
+  const cssClass =
+    visualState === "warning"
+      ? "station-placeholder station-placeholder-warning"
+      : "station-placeholder";
 
   return html`
     ${rows.map(
       () => html`
-        <ion-row class="station-placeholder">
+        <ion-row class="${cssClass}">
           ${Array.from({ length: 3 }).map(
             () => html`
               <ion-col size="4">
@@ -51,12 +129,17 @@ export class RadioPlayerTab extends RadioElement {
     this.tabName = "control";
     this.controlController = new StoreController(this, controlStore);
     this.listenController = new StoreController(this, listenStore);
+    this.registryController = new StoreController(this, registryStore);
   }
 
   get state() {
     return this.tabName === "listen"
       ? this.listenController.value
       : this.controlController.value;
+  }
+
+  get registryState() {
+    return this.registryController.value;
   }
 
   _onSelectStation(stationName) {
@@ -95,7 +178,7 @@ export class RadioPlayerTab extends RadioElement {
     `;
   }
 
-  renderStationButtons(stations, currentStation) {
+  renderStationButtons(stations, currentStation, visualState) {
     const rows = [];
     const stationsList = stations || [];
     for (let i = 0; i < stationsList.length; i += 3) {
@@ -108,11 +191,12 @@ export class RadioPlayerTab extends RadioElement {
           <ion-row>
             ${row.map((station) => {
               const isActive = station.name === currentStation;
+              const color = getStationButtonColor(visualState, isActive);
               return html`
                 <ion-col size="4">
                   <ion-button
                     expand="block"
-                    color=${isActive ? "success" : "primary"}
+                    color=${color}
                     @click=${() => this._onSelectStation(station.name)}
                   >
                     ${station.name}
@@ -128,25 +212,31 @@ export class RadioPlayerTab extends RadioElement {
 
   render() {
     const s = this.state;
+    const r = this.registryState;
+    const visualState = getStationVisualState(this.tabName, s, r);
 
     let content;
-    if (s.loading) {
-      content = renderSkeleton();
+    if (visualState === "loading") {
+      content = renderSkeleton(visualState);
     } else if (!s.stationsData) {
       content = this.renderEmptyState();
     } else {
       content = this.renderStationButtons(
         s.stationsData.stations,
         s.currentStation,
+        visualState,
       );
     }
+
+    const prefix = getTitlePrefix(this.tabName, s);
+    const suffix = getTitleSuffix(this.tabName, s, r);
 
     return html`
       <ion-header>
         <ion-toolbar>
           <ion-title size="large">
-            <span class="stations-name">${s.stationsData?.name || ""}</span>:
-            <span class="now-playing">${s.currentStation || "..."}</span>
+            <span class="stations-name">${prefix}</span>:
+            <span class="now-playing">${suffix}</span>
           </ion-title>
           <ion-buttons slot="end">
             <ion-button

--- a/remote-control/src/js/ui/radio-settings.js
+++ b/remote-control/src/js/ui/radio-settings.js
@@ -20,8 +20,13 @@ import { html } from "lit";
 import { RadioElement } from "./radio-element.js";
 import { keyed } from "lit/directives/keyed.js";
 import { StoreController } from "@nanostores/lit";
-import { preferencesStore, settingsUiStore } from "../store.js";
+import { preferencesStore, registryStore, settingsUiStore } from "../store.js";
 import { PREFERENCE_GROUPS } from "../services/preferences.js";
+import {
+  isRegistryPending,
+  getRegistryPendingTitle,
+  getRegistryPendingDetail,
+} from "./registry-status.js";
 
 const ACCOUNT_GROUP_KEY = "radio-account";
 
@@ -60,6 +65,7 @@ export function getVisiblePreferences(preferences = []) {
 export class RadioSettings extends RadioElement {
   prefsController = new StoreController(this, preferencesStore);
   uiController = new StoreController(this, settingsUiStore);
+  registryController = new StoreController(this, registryStore);
 
   _onChange() {
     if (this.uiController.value.saveState !== "saving") {
@@ -155,6 +161,21 @@ export class RadioSettings extends RadioElement {
     `;
   }
 
+  renderRegistryStatus() {
+    const r = this.registryController.value;
+    if (!isRegistryPending(r)) return "";
+
+    return html`
+      <ion-item lines="none" color="warning">
+        <ion-spinner name="crescent" slot="start"></ion-spinner>
+        <ion-label class="ion-text-wrap">
+          <h3>${getRegistryPendingTitle(r)}</h3>
+          <p>${getRegistryPendingDetail()}</p>
+        </ion-label>
+      </ion-item>
+    `;
+  }
+
   render() {
     const preferences = this.prefsController.value.definitions || {};
     const saveStateRaw = this.uiController.value.saveState;
@@ -164,6 +185,7 @@ export class RadioSettings extends RadioElement {
     const prefByGroup = groupPreferencesByGroup(preferences);
 
     return html`
+      ${this.renderRegistryStatus()}
       <ion-list id="settings-list">
         ${Object.entries(PREFERENCE_GROUPS).map(([groupKey, [label, icon]]) =>
           this.renderPreferenceGroup(

--- a/remote-control/src/js/ui/registry-status.js
+++ b/remote-control/src/js/ui/registry-status.js
@@ -16,20 +16,25 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-export {
-  alertCircleOutline,
-  checkmarkCircleOutline,
-  cloudOfflineOutline,
-  construct,
-  headset,
-  headsetOutline,
-  person,
-  personCircle,
-  radio,
-  radioOutline,
-  settings,
-  settingsOutline,
-  stop,
-  syncOutline,
-  warningOutline,
-} from "ionicons/icons";
+export function isRegistryPending(registryState) {
+  return ["loading", "retrying"].includes(registryState.phase);
+}
+
+export function formatRegistryAttempt(retryAttempt = 0) {
+  const attemptNumber = retryAttempt + 1;
+  return attemptNumber >= 10 ? "10+" : String(attemptNumber);
+}
+
+export function getRegistryPendingTitle(registryState) {
+  if (!isRegistryPending(registryState)) {
+    return null;
+  }
+
+  return `Connecting to Registry (attempt ${formatRegistryAttempt(
+    registryState.retryAttempt,
+  )})`;
+}
+
+export function getRegistryPendingDetail() {
+  return "Loading players and presets from the Registry...";
+}

--- a/remote-control/tests/actions/control-actions.test.js
+++ b/remote-control/tests/actions/control-actions.test.js
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/js/notifications.js", () => ({
+  toastWarning: vi.fn(),
+}));
+
+import { createControlActions } from "../../src/js/actions/control-actions.js";
+import { authStore, controlStore, listenStore } from "../../src/js/store.js";
+
+function createMockControl() {
+  return {
+    listeners: new Map(),
+    addEventListener(type, handler) {
+      this.listeners.set(type, handler);
+    },
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn(),
+    sendStationRequest: vi.fn(),
+  };
+}
+
+describe("control-actions", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    authStore.set({
+      enabled: false,
+      reason: "not_configured",
+      signedIn: false,
+      name: null,
+      email: null,
+      subject: null,
+      registryBearerToken: null,
+    });
+    controlStore.set({
+      player: {
+        id: null,
+        name: null,
+        stations_url: null,
+        switchboard_url: null,
+      },
+      stationsData: null,
+      currentStation: null,
+      loading: false,
+      connectionState: "idle",
+      statusText: "",
+    });
+    listenStore.set({
+      stationsData: null,
+      currentStation: null,
+      loading: false,
+      titleName: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loads control stations directly from the selected player metadata", async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        name: "Casa Briceburg",
+        stations: [{ name: "kunm" }],
+      }),
+    });
+    const control = createMockControl();
+    const listen = { setStations: vi.fn(), play: vi.fn(), stop: vi.fn() };
+    const actions = createControlActions({ control, listen });
+    const player = {
+      id: "living-room",
+      name: "Living Room",
+      stations_url: "http://localhost:3000/api/presets/briceburg",
+      switchboard_url: "ws://localhost:3000/switchboard/briceburg/living-room",
+    };
+
+    await actions.selectPlayer(player);
+
+    expect(control.connect).toHaveBeenCalledWith(player.switchboard_url, null);
+    expect(global.fetch).toHaveBeenCalledWith(
+      player.stations_url,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(controlStore.get()).toMatchObject({
+      player,
+      stationsData: {
+        name: "Casa Briceburg",
+        stations: [{ name: "kunm" }],
+      },
+      loading: false,
+      connectionState: "connected",
+    });
+  });
+
+  it("preserves existing control stations during reconnect-only recovery", async () => {
+    const control = createMockControl();
+    const listen = { setStations: vi.fn(), play: vi.fn(), stop: vi.fn() };
+    const actions = createControlActions({ control, listen });
+    const stationsData = {
+      name: "Casa Briceburg",
+      stations: [{ name: "kunm" }],
+    };
+    const player = {
+      id: "living-room",
+      name: "Living Room",
+      stations_url: "http://localhost:3000/api/presets/briceburg",
+      switchboard_url: "ws://localhost:3000/switchboard/briceburg/living-room",
+    };
+
+    controlStore.set({
+      ...controlStore.get(),
+      player,
+      stationsData,
+      currentStation: "kunm",
+      connectionState: "disconnected",
+      loading: false,
+    });
+
+    await actions.selectPlayer(player, { reconnectOnly: true });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(control.connect).toHaveBeenCalledWith(player.switchboard_url, null);
+    expect(controlStore.get()).toMatchObject({
+      player,
+      stationsData,
+      currentStation: "kunm",
+      loading: false,
+      connectionState: "connecting",
+    });
+  });
+});

--- a/remote-control/tests/ui/radio-player-tab.test.js
+++ b/remote-control/tests/ui/radio-player-tab.test.js
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  getRegistryStatusText,
+  getStationButtonColor,
+  getStationVisualState,
+  getTitlePrefix,
+  getTitleSuffix,
+  shouldRenderSkeleton,
+} from "../../src/js/ui/radio-player-tab.js";
+
+describe("radio-player-tab helpers", () => {
+  it("uses the shared registry status text in titles", () => {
+    expect(getRegistryStatusText({ phase: "loading", retryAttempt: 0 })).toBe(
+      "Connecting to Registry",
+    );
+    expect(getRegistryStatusText({ phase: "retrying", retryAttempt: 1 })).toBe(
+      "Connecting to Registry",
+    );
+  });
+
+  it("derives control and listen title prefixes", () => {
+    expect(getTitlePrefix("control", { player: { name: "Living Room" } })).toBe(
+      "Living Room",
+    );
+    expect(getTitlePrefix("listen", { titleName: "Casa Briceburg" })).toBe(
+      "Casa Briceburg",
+    );
+  });
+
+  it("shows registry attempt messaging before station data is loaded", () => {
+    expect(
+      getTitleSuffix(
+        "control",
+        { currentStation: null, loading: false, player: { id: null } },
+        { phase: "loading", retryAttempt: 0, errorText: "" },
+      ),
+    ).toBe("Connecting to Registry");
+
+    expect(
+      getTitleSuffix(
+        "listen",
+        { currentStation: null, loading: false, stationsData: null },
+        { phase: "retrying", retryAttempt: 2, errorText: "" },
+      ),
+    ).toBe("Connecting to Registry");
+  });
+
+  it("renders skeletons for pending registry discovery", () => {
+    expect(
+      shouldRenderSkeleton(
+        "control",
+        { loading: false, player: { id: null }, stationsData: null },
+        { phase: "loading" },
+      ),
+    ).toBe(true);
+    expect(
+      shouldRenderSkeleton(
+        "listen",
+        { loading: false, stationsData: null },
+        { phase: "retrying" },
+      ),
+    ).toBe(true);
+  });
+
+  it("uses warning visuals for degraded control stations", () => {
+    expect(
+      getStationVisualState(
+        "control",
+        {
+          loading: false,
+          stationsData: { stations: [] },
+          connectionState: "disconnected",
+        },
+        { phase: "ready" },
+      ),
+    ).toBe("warning");
+
+    expect(getStationButtonColor("warning", false)).toBe("warning");
+    expect(getStationButtonColor("warning", true)).toBe("success");
+  });
+
+  it("uses loading visuals while stations are still being fetched", () => {
+    expect(
+      getStationVisualState(
+        "control",
+        { loading: true, player: { id: "living-room" }, stationsData: null },
+        { phase: "ready" },
+      ),
+    ).toBe("loading");
+
+    expect(
+      getStationVisualState(
+        "listen",
+        { loading: false, stationsData: null },
+        { phase: "loading" },
+      ),
+    ).toBe("loading");
+  });
+});

--- a/remote-control/tests/ui/registry-status.test.js
+++ b/remote-control/tests/ui/registry-status.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatRegistryAttempt,
+  getRegistryPendingTitle,
+  isRegistryPending,
+} from "../../src/js/ui/registry-status.js";
+
+describe("registry-status helpers", () => {
+  it("treats loading and retrying as pending", () => {
+    expect(isRegistryPending({ phase: "loading" })).toBe(true);
+    expect(isRegistryPending({ phase: "retrying" })).toBe(true);
+    expect(isRegistryPending({ phase: "ready" })).toBe(false);
+  });
+
+  it("formats attempt counts starting at one and caps at 10+", () => {
+    expect(formatRegistryAttempt(0)).toBe("1");
+    expect(formatRegistryAttempt(1)).toBe("2");
+    expect(formatRegistryAttempt(9)).toBe("10+");
+  });
+
+  it("builds the shared registry title for loading and retrying states", () => {
+    expect(getRegistryPendingTitle({ phase: "loading", retryAttempt: 0 })).toBe(
+      "Connecting to Registry (attempt 1)",
+    );
+    expect(
+      getRegistryPendingTitle({ phase: "retrying", retryAttempt: 2 }),
+    ).toBe("Connecting to Registry (attempt 3)");
+    expect(getRegistryPendingTitle({ phase: "ready", retryAttempt: 0 })).toBe(
+      null,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds visual degraded-state feedback to the remote-control when connectivity is impaired.

**Depends on:** PR #65 (RC registry resilience)

### Changes

**Connection state tracking** — `controlStore.connectionState` flows through `idle → connecting → connected → disconnected`, driving UI decisions about skeleton rendering and button colors.

**Station fetch lifecycle** — Uses `AbortController` to cancel in-flight station fetches when the player changes, preventing stale data. Adds `reconnectOnly` option to `selectPlayer()` so switchboard recovery skips re-fetching stations.

**Visual state machine** — New helpers (`getStationVisualState`, `shouldRenderSkeleton`, `getStationButtonColor`) derive the correct rendering from the combined control + registry state:
- `loading` → animated skeleton placeholders (normal)
- `warning` → amber skeleton placeholders (degraded)
- `normal` → blue/green station buttons

**Registry status banner** — Settings tab shows a spinner with attempt count while registry discovery is pending.

**Title bar** — Dynamically composed from player name, station name, and registry status. Listen tab shows preset label via `titleName`.

**Emoji removal** — Strips emoji prefixes from error/status messages across `control-actions`, `app`, `auth.js` for cleaner output.

### New files
- `src/js/ui/registry-status.js` — Shared registry pending detection and formatting

### Tests
- 11 new tests across 3 files (38 total, all passing)
- `tests/actions/control-actions.test.js` — station loading, reconnectOnly
- `tests/ui/radio-player-tab.test.js` — visual state, skeletons, titles
- `tests/ui/registry-status.test.js` — pending detection, formatting
