### PR TITLE
feat(macropad-control): class-based refactor with status protocol & visual states

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,28 @@ bin/ci
 COMPOSE_FILE=compose.split.yaml bin/ci
 ```
 
+### Local macropad testing
+
+If you change the macropad firmware in [`macropad-control`](./macropad-control/), sync it to the device first:
+
+```sh
+cd macropad-control
+bin/refresh
+```
+
+The default compose files do not expose host USB serial devices to the `player` container. For end-to-end testing with a real macropad attached, layer in the macropad overlay:
+
+```sh
+# determine the macropad serial port
+macropad-control/bin/status
+
+# start with macropad overlay
+RADIOPAD_MACROPAD_PORT=/dev/ttyACM1 \
+docker compose -f compose.yaml -f compose.macropad.yaml up
+```
+
+If `bin/status` shows no ports, the macropad is not visible to this Linux environment. In WSL2, the USB device must be attached via USB/IP first.
+
 ## Architecture
 
 ### Deployment modes

--- a/compose.macropad.yaml
+++ b/compose.macropad.yaml
@@ -1,0 +1,7 @@
+services:
+  player:
+    user: root
+    environment:
+      RADIOPAD_MACROPAD_PORT: "${RADIOPAD_MACROPAD_PORT:-/dev/ttyACM1}"
+    devices:
+      - "${RADIOPAD_MACROPAD_PORT:-/dev/ttyACM1}:${RADIOPAD_MACROPAD_PORT:-/dev/ttyACM1}"

--- a/macropad-control/README.md
+++ b/macropad-control/README.md
@@ -34,6 +34,12 @@ A linux host is assumed, with the macropad plugged into it. It must have python3
    bin/mount
    ```
 
+   To inspect detected devices without mounting, run:
+
+   ```sh
+   bin/status
+   ```
+
 2. **Customize button colors and behavior:**
    - Edit [`src/main.py`](./src/main.py) to change macropad key behavior.
    - Stations are received from the connected [player](../player/), which loads them from a registry [station preset](../player/README.md#registry-discovery).
@@ -43,6 +49,8 @@ A linux host is assumed, with the macropad plugged into it. It must have python3
    bin/refresh
    ```
 
+   `bin/refresh` will automatically run `bin/mount` if the CIRCUITPY volume is not mounted yet.
+
 4. **Debug via the USB serial console**
 
 Attaching to the console allows you to read stdout/stderr, for instance to view exceptions or debug messages.
@@ -51,7 +59,16 @@ Attaching to the console allows you to read stdout/stderr, for instance to view 
   bin/console
   ```
 
-  > this command requires that the executing user has access to /dev/ttyACM* devices, which are owned by the `uucp` group in archlinux.
+  The player uses the CircuitPython `CDC2` port for commands and events, while `bin/console` targets the primary CircuitPython console port.
+
+  > Serial access requires that the executing user has access to `/dev/ttyACM*` devices, which are owned by the `uucp` group in archlinux.
+
+### WSL Notes
+
+In WSL2, the macropad needs to be attached into Linux with USB/IP before the storage and `/dev/ttyACM*` devices appear. Once attached, this project expects:
+
+- player data port: `/dev/ttyACM1` (`CircuitPython CDC2`)
+- console port: `/dev/ttyACM0` (`CircuitPython CDC`)
 
 ## Development
 

--- a/macropad-control/README.md
+++ b/macropad-control/README.md
@@ -8,8 +8,21 @@ Use the [Adafruit Macropad RP2040](https://learn.adafruit.com/adafruit-macropad-
 
 ## How It Works
 
-- The Macropad sends coded keypresses to a host.
-- The host runs a [listener script](../player/) that detects these keypresses and starts/stops playback of the corresponding radio stream(s).
+- The Macropad communicates with a host [player](../player/) over USB serial (CircuitPython CDC2).
+- The player sends station lists, heartbeats, and status events; the macropad renders them on its display and NeoPixel keys.
+- Pressing a key sends a station request to the player.
+
+### Visual States
+
+| State | Display Title | NeoPixel Keys |
+|-------|--------------|---------------|
+| Waiting for Player | "Waiting for Player" | Grey breathing animation |
+| Loading stations | "Loading stations" | Amber breathing animation |
+| Healthy | Station/page name | Blue (default) / Green (playing) |
+| Upstream degraded | Status text (e.g. "Switchboard lost") | Amber keys |
+| Playback issue | Status text (e.g. "Playback failed") | Normal colors |
+
+The macropad detects a lost player session by tracking heartbeats — if no message arrives within 5 seconds, it reverts to the "Waiting for Player" state.
 
 ## Macropad Controls
 

--- a/macropad-control/bin/console
+++ b/macropad-control/bin/console
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
-dev=$(find /dev/serial/by-id/ -type l -name '*Macropad*' | sort | head -n1)
-if [ -z "$dev" ]; then
-  echo "No Macropad device found."
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./libmacropad
+source "$SCRIPT_DIR/libmacropad"
+
+dev="$(find_macropad_console_port 2>/dev/null || true)"
+[ -n "$dev" ] || dev="$(find /dev/serial/by-id/ -type l -name '*Macropad*' 2>/dev/null | sort | head -n1)"
+[ -n "$dev" ] || {
+  echo "No Macropad console port found." >&2
+  echo "Try 'bin/status' to inspect detected storage and serial ports." >&2
   exit 1
-fi
+}
+
+echo "[info] opening console on $dev"
 
 screen "$dev" 115200

--- a/macropad-control/bin/libmacropad
+++ b/macropad-control/bin/libmacropad
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+macropad_mount_target() {
+  echo "${RADIOPAD_MACROPAD_MOUNT:-/mnt/CIRCUITPY}"
+}
+
+find_circuitpy_block_device() {
+  if [ -n "${RADIOPAD_MACROPAD_DISK:-}" ]; then
+    echo "$RADIOPAD_MACROPAD_DISK"
+    return 0
+  fi
+
+  if [ -e /dev/disk/by-label/CIRCUITPY ]; then
+    readlink -f /dev/disk/by-label/CIRCUITPY
+    return 0
+  fi
+
+  if command -v lsblk >/dev/null 2>&1; then
+    local disk
+    disk="$(lsblk -pnro PATH,LABEL | awk '$2=="CIRCUITPY"{print $1; exit}')"
+    if [ -n "$disk" ]; then
+      echo "$disk"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+find_macropad_port_by_prefix() {
+  local prefix="$1"
+  local interface_file
+
+  for interface_file in /sys/class/tty/ttyACM*/device/interface /sys/class/tty/ttyUSB*/device/interface; do
+    [ -e "$interface_file" ] || continue
+
+    if grep -q "^${prefix}" "$interface_file"; then
+      basename "$(dirname "$(dirname "$interface_file")")"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+find_macropad_data_port() {
+  if [ -n "${RADIOPAD_MACROPAD_PORT:-}" ]; then
+    echo "$RADIOPAD_MACROPAD_PORT"
+    return 0
+  fi
+
+  local tty_name
+  tty_name="$(find_macropad_port_by_prefix "CircuitPython CDC2")" || return 1
+  echo "/dev/${tty_name}"
+}
+
+find_macropad_console_port() {
+  if [ -n "${RADIOPAD_MACROPAD_CONSOLE_PORT:-}" ]; then
+    echo "$RADIOPAD_MACROPAD_CONSOLE_PORT"
+    return 0
+  fi
+
+  local tty_name
+  tty_name="$(find_macropad_port_by_prefix "CircuitPython CDC control")" || return 1
+  echo "/dev/${tty_name}"
+}

--- a/macropad-control/bin/mount
+++ b/macropad-control/bin/mount
@@ -1,10 +1,28 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-my_id=$(id -u)
-disk="/dev/disk/by-label/CIRCUITPY"
-target="/mnt/CIRCUITPY"
-[ -d "$target" ] || sudo mkdir -p "$target"
-sudo umount "$target" || true
-sudo mount "$disk" "$target" -o uid="$my_id" -o rw
-echo "[ok] mounted disk to /mnt/CIRCUITPY under uid $my_id"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./libmacropad
+source "$SCRIPT_DIR/libmacropad"
+
+my_id="$(id -u)"
+target="$(macropad_mount_target)"
+disk="$(find_circuitpy_block_device)" || {
+  echo "No CIRCUITPY block device found. Is the macropad storage exposed to this Linux environment?" >&2
+  exit 1
+}
+
+if [ "$EUID" -eq 0 ]; then
+  SUDO=()
+else
+  SUDO=(sudo)
+fi
+
+[ -d "$target" ] || "${SUDO[@]}" mkdir -p "$target"
+
+if mountpoint -q "$target" 2>/dev/null; then
+  "${SUDO[@]}" umount "$target"
+fi
+
+"${SUDO[@]}" mount "$disk" "$target" -o uid="$my_id",rw
+echo "[ok] mounted $disk to $target under uid $my_id"

--- a/macropad-control/bin/refresh
+++ b/macropad-control/bin/refresh
@@ -1,19 +1,25 @@
 #!/usr/bin/env bash
 set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(git rev-parse --show-toplevel)/macropad-control"
+# shellcheck source=./libmacropad
+source "$SCRIPT_DIR/libmacropad"
 
-mount | grep -q /mnt/CIRCUITPY || {
-  echo "macropad not mounted, please run bin/mount and try again." >&2
-  exit 1
-}
+target="$(macropad_mount_target)"
 
-cd /mnt/CIRCUITPY/
+if ! mountpoint -q "$target" 2>/dev/null; then
+  echo "[info] macropad not mounted, attempting bin/mount"
+  "$SCRIPT_DIR/mount"
+fi
+
+cd "$target"
 
 if [ "${1:-}" = "--hard" ]; then
   echo "removing existing files"
   rm -rf ./*
 fi
 
-cp -r "$PROJECT_ROOT"/src/* .
+cp -r "$PROJECT_ROOT"/src/. .
 sync
-echo "[ok] copied files"
+echo "[ok] copied files to $target"

--- a/macropad-control/bin/status
+++ b/macropad-control/bin/status
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./libmacropad
+source "$SCRIPT_DIR/libmacropad"
+
+target="$(macropad_mount_target)"
+
+echo "mount target: $target"
+if mountpoint -q "$target" 2>/dev/null; then
+  echo "storage: mounted"
+else
+  echo "storage: not mounted"
+fi
+
+if disk="$(find_circuitpy_block_device 2>/dev/null)"; then
+  echo "storage device: $disk"
+else
+  echo "storage device: not found"
+fi
+
+if console_port="$(find_macropad_console_port 2>/dev/null)"; then
+  echo "console port: $console_port"
+else
+  echo "console port: not found"
+fi
+
+if data_port="$(find_macropad_data_port 2>/dev/null)"; then
+  echo "player data port: $data_port"
+else
+  echo "player data port: not found"
+fi

--- a/macropad-control/src/lib/macropad_display.py
+++ b/macropad-control/src/lib/macropad_display.py
@@ -23,11 +23,16 @@ from adafruit_display_text import label
 
 from .macropad_keys import MACROPAD_KEY_COUNT
 
+TITLE_MAX_CHARS = 18
+STATION_LABEL_MAX_CHARS = 6
+TITLE_TRUNCATION_SUFFIX = ">"
+
 
 class MacropadDisplay:
     def __init__(self, macropad):
         self.macropad = macropad
         self.macropad.display.auto_refresh = False
+        self._max_text_length = TITLE_MAX_CHARS
         self._group = displayio.Group()
 
         for group_index in range(MACROPAD_KEY_COUNT):
@@ -60,7 +65,32 @@ class MacropadDisplay:
 
         self.macropad.display.root_group = self._group
 
+    def _normalize_text(self, text):
+        if not isinstance(text, str):
+            text = "" if text is None else str(text)
+
+        if len(text) <= self._max_text_length:
+            return text
+
+        if self._max_text_length <= len(TITLE_TRUNCATION_SUFFIX):
+            return text[: self._max_text_length]
+
+        return (
+            text[: self._max_text_length - len(TITLE_TRUNCATION_SUFFIX)]
+            + TITLE_TRUNCATION_SUFFIX
+        )
+
+    def normalize_station_label(self, text):
+        if not isinstance(text, str):
+            text = "" if text is None else str(text)
+
+        if len(text) <= STATION_LABEL_MAX_CHARS:
+            return text
+
+        return text[:STATION_LABEL_MAX_CHARS]
+
     def set_title(self, text, refresh=True):
+        text = self._normalize_text(text)
         if self._title_text.text == text:
             return
         self._title_text.text = text
@@ -69,7 +99,7 @@ class MacropadDisplay:
 
     def set_group_text(self, group_index, text):
         if 0 <= group_index < MACROPAD_KEY_COUNT:
-            self._group[group_index].text = text
+            self._group[group_index].text = self.normalize_station_label(text)
 
     def highlight_group(self, group_index):
         if 0 <= group_index < MACROPAD_KEY_COUNT:

--- a/macropad-control/src/lib/macropad_keys.py
+++ b/macropad-control/src/lib/macropad_keys.py
@@ -22,6 +22,14 @@ DEFAULT_COLOR = 0x000077
 PLAYING_COLOR = 0x015C01
 PRESSED_COLOR = 0x999999
 MACROPAD_KEY_COUNT = 12
+UPSTREAM_WARNING_COLOR = 0x402000
+WAITING_ANIMATION_PERIOD = 1.6
+WAITING_DISCONNECTED_LED_MAX = 0x40
+WAITING_LOADING_LED_MAX = 0x50
+WAITING_ROW_PHASE_STEP = 0.12
+WAITING_COLUMN_PHASE_STEP = 0.08
+WAITING_MODE_DISCONNECTED = "disconnected"
+WAITING_MODE_LOADING = "loading"
 
 
 class MacropadKeys:
@@ -33,6 +41,10 @@ class MacropadKeys:
         self.stations = []
         self.playing_station_index = None
         self.current_page_index = 0
+        self.title_override = None
+        self.waiting_animation_mode = None
+        self.upstream_warning = False
+        self._last_animation_tick = 0.0
         self.pages = [{"stations": [], "title": "iCEBURG Radio"}]
 
     def set_stations(self, stations_list):
@@ -59,11 +71,35 @@ class MacropadKeys:
         self.current_page_index = page_index
         self.refresh()
 
+    def set_title_override(self, title):
+        normalized = title if isinstance(title, str) and title else None
+        if self.title_override == normalized:
+            return
+        self.title_override = normalized
+        self.refresh()
+
+    def set_waiting_animation(self, mode):
+        normalized = (
+            mode if mode in (WAITING_MODE_DISCONNECTED, WAITING_MODE_LOADING) else None
+        )
+        if self.waiting_animation_mode == normalized:
+            return
+        self.waiting_animation_mode = normalized
+        self._last_animation_tick = 0.0
+        self.refresh()
+
+    def set_upstream_warning(self, enabled):
+        enabled = bool(enabled)
+        if self.upstream_warning == enabled:
+            return
+        self.upstream_warning = enabled
+        self.refresh()
+
     def refresh(self):
         page = self.pages[self.current_page_index]
 
-        title = page["title"]
-        if self.playing_station_index is not None:
+        title = self.title_override or page["title"]
+        if self.title_override is None and self.playing_station_index is not None:
             station_page_index = self.get_station_page_index(self.playing_station_index)
             if self.current_page_index == station_page_index:
                 station_index_on_page = self.playing_station_index % MACROPAD_KEY_COUNT
@@ -82,13 +118,20 @@ class MacropadKeys:
                     self.macropad.pixels[i] = PLAYING_COLOR
                     self.display.highlight_group(i)
                 else:
-                    self.macropad.pixels[i] = station.get("color", DEFAULT_COLOR)
+                    self.macropad.pixels[i] = self._station_color(station)
             else:
                 self.macropad.pixels[i] = 0
                 self.display.set_group_text(i, "")
 
+        if self.waiting_animation_mode:
+            self._animate_waiting_pixels(force=True)
+
         self.macropad.pixels.show()
         self.display.refresh()
+
+    def tick(self):
+        if self.waiting_animation_mode:
+            self._animate_waiting_pixels()
 
     def set_key_color(self, key_index, color):
         if 0 <= key_index < MACROPAD_KEY_COUNT:
@@ -124,3 +167,39 @@ class MacropadKeys:
         self.macropad.pixels.show()
         time.sleep(duration)
         self.refresh()
+
+    def _station_color(self, station):
+        if self.upstream_warning:
+            return UPSTREAM_WARNING_COLOR
+        return station.get("color", DEFAULT_COLOR)
+
+    def _animate_waiting_pixels(self, force=False):
+        now = time.monotonic()
+        if not force and now - self._last_animation_tick < 0.05:
+            return
+
+        self._last_animation_tick = now
+        animation_position = (now / WAITING_ANIMATION_PERIOD) % 1.0
+        for key_index in range(MACROPAD_KEY_COUNT):
+            phase = (
+                animation_position
+                + (key_index // 3) * WAITING_ROW_PHASE_STEP
+                + (key_index % 3) * WAITING_COLUMN_PHASE_STEP
+            ) % 1.0
+            level = self._triangle_wave(phase)
+            self.macropad.pixels[key_index] = self._waiting_animation_color(level)
+        self.macropad.pixels.show()
+
+    def _triangle_wave(self, phase):
+        if phase < 0.5:
+            return phase * 2
+        return (1.0 - phase) * 2
+
+    def _waiting_animation_color(self, level):
+        if self.waiting_animation_mode == WAITING_MODE_LOADING:
+            red = int(WAITING_LOADING_LED_MAX * level)
+            green = int((WAITING_LOADING_LED_MAX // 2) * level)
+            return (red << 16) | (green << 8)
+
+        grey = int(WAITING_DISCONNECTED_LED_MAX * level)
+        return (grey << 16) | (grey << 8) | grey

--- a/macropad-control/src/lib/macropad_player.py
+++ b/macropad-control/src/lib/macropad_player.py
@@ -21,6 +21,9 @@ import time
 
 import usb_cdc
 
+PLAYER_SESSION_TIMEOUT_SECONDS = 5
+SERIAL_WRITE_BACKPRESSURE_SECONDS = 0.1
+
 
 class MacropadPlayer:
     def __init__(self):
@@ -29,37 +32,62 @@ class MacropadPlayer:
             raise RuntimeError("No USB CDC data port found.")
         self._serial_buffer = ""
         self._last_station_request_time = 0
+        self._last_player_message_time = 0.0
 
     @property
     def connected(self):
-        return self.player.connected
+        try:
+            return bool(self.player.connected)
+        except Exception as e:
+            print(f"PLAYER: error checking connection state: {e}")
+            return False
+
+    @property
+    def session_connected(self):
+        return self.connected and (
+            time.monotonic() - self._last_player_message_time
+            < PLAYER_SESSION_TIMEOUT_SECONDS
+        )
 
     def send_command(self, event, data=None):
-        if self.connected:
-            message = json.dumps({"event": event, "data": data})
+        if not self.connected:
+            return
+
+        message = json.dumps({"event": event, "data": data})
+        try:
             self.player.write(f"{message}\n".encode())
-            time.sleep(0.1)  # Handle backpressure
+            time.sleep(SERIAL_WRITE_BACKPRESSURE_SECONDS)
+        except Exception as e:
+            print(f"PLAYER: error sending command: {e}")
+            self.reset_session()
 
     def read_event(self):
-        if self.player.in_waiting > 0:
+        try:
+            in_waiting = self.player.in_waiting
+        except Exception as e:
+            print(f"PLAYER: error checking serial buffer: {e}")
+            self.reset_session()
+            return None
+
+        if "\n" not in self._serial_buffer and in_waiting > 0:
             try:
-                self._serial_buffer += self.player.read(self.player.in_waiting).decode(
-                    "utf-8"
-                )
+                self._serial_buffer += self.player.read(in_waiting).decode("utf-8")
             except Exception as e:
                 print(f"PLAYER: error reading serial buffer: {e}")
+                self.reset_session()
                 return None
 
-            if "\n" in self._serial_buffer:
-                line, self._serial_buffer = self._serial_buffer.split("\n", 1)
-                line = line.strip()
-                if not line:
-                    return None
-                try:
-                    msg = json.loads(line)
-                    return msg
-                except Exception as e:
-                    print(f"PLAYER: error parsing message: {e}")
+        if "\n" in self._serial_buffer:
+            line, self._serial_buffer = self._serial_buffer.split("\n", 1)
+            line = line.strip()
+            if not line:
+                return None
+            try:
+                msg = json.loads(line)
+                self._last_player_message_time = time.monotonic()
+                return msg
+            except Exception as e:
+                print(f"PLAYER: error parsing message: {e}")
         return None
 
     def request_stations(self):
@@ -71,3 +99,7 @@ class MacropadPlayer:
     def flush_buffer(self):
         while self.read_event():
             pass
+
+    def reset_session(self):
+        self._serial_buffer = ""
+        self._last_player_message_time = 0.0

--- a/macropad-control/src/main.py
+++ b/macropad-control/src/main.py
@@ -24,87 +24,200 @@ from lib.macropad_display import MacropadDisplay
 from lib.macropad_keys import DEFAULT_COLOR, PRESSED_COLOR, MacropadKeys
 from lib.macropad_player import MacropadPlayer
 
-macropad = MacroPad()
-display = MacropadDisplay(macropad)
-keys = MacropadKeys(macropad, display)
-player = MacropadPlayer()
+LOOP_SLEEP_SECONDS = 0.01
+STATUS_SCOPES = ("upstream", "playback")
 
-last_position = macropad.encoder
-last_encoder_switch = macropad.encoder_switch_debounced.pressed
-had_stations = False
 
-display.set_title("Connect to Player")
+class MacropadApp:
+    def __init__(self):
+        self.macropad = MacroPad()
+        self.display = MacropadDisplay(self.macropad)
+        self.keys = MacropadKeys(self.macropad, self.display)
+        self.player = MacropadPlayer()
 
-while True:
-    # --- Player Connection ---
-    if player.connected and not had_stations:
-        display.set_title("Player connected!")
-        display.refresh()
-        player.request_stations()
-    elif not player.connected:
-        if had_stations:
-            keys.set_stations([])
-            display.set_title("Player disconnected!")
-            player.flush_buffer()
-            had_stations = False
+        self.last_position = self.macropad.encoder
+        self.last_encoder_switch = self.macropad.encoder_switch_debounced.pressed
+        self.had_stations = False
+        self.was_connected = False
+        self.status_by_scope = {scope: "" for scope in STATUS_SCOPES}
 
-        time.sleep(0.01)
-        continue
+    def run(self):
+        while True:
+            self.tick()
+            time.sleep(LOOP_SLEEP_SECONDS)
 
-    # --- Player Events ---
-    event = player.read_event()
-    if event:
-        print(f"Received event: {event}")
+    def tick(self):
+        event = self.player.read_event()
+
+        if not self.player.session_connected:
+            self._handle_disconnected_state(event)
+            self.keys.tick()
+            return
+
+        if not self.was_connected:
+            self._refresh_visual_state()
+            self.was_connected = True
+
+        if not self.had_stations:
+            self.player.request_stations()
+
+        self._handle_player_event(event)
+        self._handle_encoder_rotation()
+        self._handle_encoder_press()
+        self._handle_key_events()
+        self.keys.tick()
+
+    def _handle_disconnected_state(self, event):
+        self._handle_player_event(event)
+
+        if self.player.session_connected:
+            self._refresh_visual_state()
+            self.was_connected = True
+            return
+
+        if self.had_stations:
+            self.keys.set_stations([])
+            self.keys.set_playing_station(None)
+            self.had_stations = False
+
+        if self.was_connected or any(self.status_by_scope.values()):
+            self.player.flush_buffer()
+            self.player.reset_session()
+
+        self.was_connected = False
+        self._clear_statuses()
+        self._refresh_visual_state()
+
+        if self.player.connected:
+            self.player.request_stations()
+
+    def _handle_player_event(self, event):
+        if not event:
+            return
+
         event_name = event.get("event")
         data = event.get("data")
 
         if event_name == "station_list":
-            station_list = [
-                {"name": station, "color": DEFAULT_COLOR} for station in data
-            ]
-            keys.set_stations(station_list)
-            had_stations = True
-        elif event_name == "station_playing":
-            keys.set_playing_station(data)
+            self._set_station_list(data)
+            return
 
-    # --- Encoder Rotation ---
-    position = macropad.encoder
-    if position != last_position:
-        if keys.playing_station_index is not None:
-            direction = "up" if position > last_position else "down"
-            player.send_command("volume", direction)
+        if event_name == "station_playing":
+            self.keys.set_playing_station(data)
+            return
+
+        if event_name == "player_status":
+            self._update_status(data)
+            self._refresh_visual_state()
+            return
+
+        if event_name != "player_heartbeat":
+            print(f"Received event: {event}")
+
+    def _set_station_list(self, stations):
+        station_list = [
+            {"name": station, "color": DEFAULT_COLOR} for station in stations
+        ]
+        self.keys.set_stations(station_list)
+        self.had_stations = True
+        self._refresh_visual_state()
+
+    def _handle_encoder_rotation(self):
+        position = self.macropad.encoder
+        if position == self.last_position:
+            return
+
+        if self.keys.playing_station_index is not None:
+            direction = "up" if position > self.last_position else "down"
+            self.player.send_command("volume", direction)
         else:
-            num_pages = len(keys.pages)
-            if position > last_position:
-                keys.switch_page((keys.current_page_index + 1) % num_pages)
-            else:
-                keys.switch_page((keys.current_page_index - 1 + num_pages) % num_pages)
-        last_position = position
+            page_count = len(self.keys.pages)
+            direction = 1 if position > self.last_position else -1
+            next_page = (self.keys.current_page_index + direction) % page_count
+            self.keys.switch_page(next_page)
 
-    # --- Encoder Press ---
-    macropad.encoder_switch_debounced.update()
-    pressed = macropad.encoder_switch_debounced.pressed
-    if pressed and not last_encoder_switch:
-        if keys.playing_station_index is not None:
-            player.send_command("station_request", None)
-            keys.flash_keys()
-    last_encoder_switch = pressed
+        self.last_position = position
 
-    # --- Key Events ---
-    last_pressed_station = None
-    while True:
-        # Drain keypad event queue so simultaneous presses resolve to the "last" press.
-        key_event = macropad.keys.events.get()
-        if not key_event:
-            break
-        if not key_event.pressed:
-            continue
+    def _handle_encoder_press(self):
+        self.macropad.encoder_switch_debounced.update()
+        pressed = self.macropad.encoder_switch_debounced.pressed
+        if pressed and not self.last_encoder_switch:
+            if self.keys.playing_station_index is not None:
+                self.player.send_command("station_request", None)
+                self.keys.flash_keys()
+        self.last_encoder_switch = pressed
 
-        key_number = key_event.key_number
-        station_name = keys.get_station_name(key_number)
+    def _handle_key_events(self):
+        station_name = self._drain_pressed_station_name()
         if station_name:
-            keys.set_key_color(key_number, PRESSED_COLOR)
-            last_pressed_station = station_name
+            self.player.send_command("station_request", station_name)
 
-    if last_pressed_station:
-        player.send_command("station_request", last_pressed_station)
+    def _drain_pressed_station_name(self):
+        last_pressed_station = None
+        while True:
+            key_event = self.macropad.keys.events.get()
+            if not key_event:
+                return last_pressed_station
+            if not key_event.pressed:
+                continue
+
+            key_number = key_event.key_number
+            station_name = self.keys.get_station_name(key_number)
+            if station_name:
+                self.keys.set_key_color(key_number, PRESSED_COLOR)
+                last_pressed_station = station_name
+
+    def _update_status(self, status_event):
+        if not isinstance(status_event, dict):
+            print(f"Unexpected player_status payload: {status_event}")
+            return
+
+        scope = status_event.get("scope")
+        summary = status_event.get("summary")
+
+        if scope not in self.status_by_scope:
+            print(f"Unexpected player_status scope: {scope}")
+            return
+
+        if isinstance(summary, str):
+            self.status_by_scope[scope] = summary
+            return
+
+        if summary is not None:
+            print(f"Unexpected player_status summary: {summary}")
+        self.status_by_scope[scope] = ""
+
+    def _clear_statuses(self):
+        for scope in self.status_by_scope:
+            self.status_by_scope[scope] = ""
+
+    def _refresh_visual_state(self):
+        self.keys.set_waiting_animation(self._waiting_mode())
+        self.keys.set_upstream_warning(
+            self.had_stations and bool(self.status_by_scope["upstream"])
+        )
+        self.keys.set_title_override(self._title_override())
+
+    def _waiting_mode(self):
+        if not self.player.session_connected:
+            return "disconnected"
+        if not self.had_stations:
+            return "loading"
+        return None
+
+    def _title_override(self):
+        if not self.player.session_connected:
+            return "Waiting for Player"
+
+        for scope in ("playback", "upstream"):
+            status = self.status_by_scope[scope]
+            if status:
+                return status
+
+        if not self.had_stations:
+            return "Loading stations"
+
+        return None
+
+
+MacropadApp().run()

--- a/player/README.md
+++ b/player/README.md
@@ -42,6 +42,7 @@ name | description | default
 `RADIOPAD_ENABLE_DISCOVERY` | Enables discovery based on RADIOPAD_PLAYER_ID. Anything other than "true" will disable. | `true`
 `RADIOPAD_MPV_SOCKET_PATH` | Path to the mpv IPC socket. | `/tmp/radio-pad-mpv.sock`
 `RADIOPAD_HEALTH_PATH` | Path to the player readiness file used by the container healthcheck. | `/tmp/radio-pad-ready`
+`RADIOPAD_MACROPAD_PORT` | Explicit serial device path for the macropad USB data port. Useful in containers where auto-discovery metadata is missing. | `None`
 `RADIOPAD_PLAYER` | Name of player in `{account_id}/{player_id}` format, used for [registry discovery](#registry-discovery). | `briceburg/living-room`
 `RADIOPAD_REGISTRY_URL` | Registry URL for [discovery](#registry-discovery). | `https://registry.radiopad.dev/api`
 `RADIOPAD_STATIONS_URL` | URL returning a station preset JSON object. Discovered from the registry if not set. | `None`
@@ -90,6 +91,25 @@ options snd-usb-audio index=0,1 vid=0x041e,0x239a pid=0x324d,0x8108
 ## Development
 
 For compose-based development with all services, see the [root README](../README.md#development).
+
+For containerized testing with a real macropad attached, determine the device path first:
+
+```sh
+python -m serial.tools.list_ports -v
+
+# or from the repo root:
+macropad-control/bin/status
+
+# or, on a typical Linux host:
+ls -l /dev/ttyACM* /dev/ttyUSB*
+```
+
+Then pass the device through to the player service:
+
+```sh
+RADIOPAD_MACROPAD_PORT=/dev/ttyACM1 \
+docker compose -f compose.yaml -f compose.macropad.yaml up player
+```
 
 ### Contributing
 

--- a/player/src/lib/client_macropad.py
+++ b/player/src/lib/client_macropad.py
@@ -19,6 +19,7 @@
 
 import asyncio
 import logging
+import os
 
 import serial.tools.list_ports
 import serial_asyncio
@@ -60,18 +61,28 @@ class MacropadClient(RadioPadClient):
             logger.info("reconnecting in 3s...")
             await asyncio.sleep(3)
 
-    async def _connect(self):
-        macropad_ports = [
+    def _candidate_ports(self):
+        configured_port = os.getenv("RADIOPAD_MACROPAD_PORT")
+        if configured_port:
+            return [configured_port]
+
+        return [
             port.device
             for port in serial.tools.list_ports.comports()
             if port.interface and port.interface.startswith(DATA_INTERFACE_NAME)
         ]
 
+    async def _connect(self):
+        macropad_ports = self._candidate_ports()
+
         if not macropad_ports:
             logger.warning("no data ports found, is it plugged in?")
             return None, None
 
-        logger.info("found ports: %s", macropad_ports)
+        if os.getenv("RADIOPAD_MACROPAD_PORT"):
+            logger.info("using configured macropad port: %s", macropad_ports[0])
+        else:
+            logger.info("found ports: %s", macropad_ports)
         for macropad_port in macropad_ports:
             logger.info("attempting to connect to %s", macropad_port)
             try:


### PR DESCRIPTION
## Summary

Complete refactor of macropad-control from a flat main loop into a structured class-based application with heartbeat-based session detection, scoped status display, and visual state feedback via breathing LED animations.

**Depends on:** PR #64 (player status protocol), PR #61 (macropad tooling)

### Architecture

`MacropadApp` class replaces the flat `while True:` loop. Each tick handles:
1. Read event from serial
2. Determine connection state (session timeout = 5s without any player message)
3. Dispatch to appropriate handler (`_handle_disconnected_state`, `_handle_player_event`, input handlers)
4. Update visual state

### Visual State Machine

| State | Display | Keys |
|-------|---------|------|
| Waiting for Player | "Waiting for Player" | Grey breathing animation |
| Loading stations | "Loading stations" | Amber breathing animation |
| Healthy | Station/page name | Blue (default) / Green (playing) |
| Upstream degraded | Status text | Amber warning keys |
| Playback issue | Status text | Normal colors |

### Key Changes

**`main.py`** — Refactored from 110-line flat loop → `MacropadApp` class with clear method boundaries. Handles `player_status` events (scoped to `upstream`/`playback`), `player_heartbeat` for session keepalive, and visual state refresh after every state transition.

**`macropad_keys.py`** — Added:
- `set_waiting_animation(mode)`: breathing LED effect (grey=disconnected, amber=loading)
- `set_upstream_warning(enabled)`: turns station keys amber
- `set_title_override(title)`: status messages override page title
- `tick()`: called every loop iteration for smooth animation

**`macropad_display.py`** — Text normalization: title truncated to 18 chars, station labels to 6 chars (OLED constraints).

**`macropad_player.py`** — Session awareness:
- `session_connected` property (USB connected + message within 5s)
- Error handling on all serial I/O with `reset_session()` recovery
- Named constants for timeout and backpressure values

### Status Protocol

Consumes events from the player (see PR #64):
- `player_heartbeat` — resets the session timeout timer
- `player_status` `{scope: "upstream"|"playback", summary: "..."}` — drives title override and amber keys
- `station_list` / `station_playing` — existing events, unchanged

### Notes
- CircuitPython code — no unit tests (hardware-dependent). Verified via code review and linting.
- README updated with visual state table.
